### PR TITLE
Fix remove_tables_from_model() and add datainfo preservation test

### DIFF
--- a/R/remove_tables_from_model.R
+++ b/R/remove_tables_from_model.R
@@ -20,22 +20,11 @@ remove_tables_from_model <- function(
       return(model)
     }
 
-    ## workaround for dataset needed to circumvent issues re-reading the model file
-    data <- model$dataset
-    if(!is.null(data)) {
-      temp_csv <- paste0(tempfile(), ".csv")
-      write.csv(data, temp_csv, quote=F, row.names=F)
-      model <- pharmr::set_dataset(model, temp_csv)
-    }
+    ## Reread model without tables
     code_without_tables <- remove_table_sections(model$code, file = file)
-    model <- pharmr::read_model_from_string(
-      code = code_without_tables
-    )
-
-    ## read_model_from_string() will strip the dataset, need to re-add:
-    if(!is.null(data)) {
-      model <- pharmr::set_dataset(model, path_or_df = data)
-    }
+    temp_mod <- tempfile(pattern = "tmp_mod_", fileext = '.mod')
+    writeLines(code_without_tables, temp_mod)
+    model <- create_model_from_file(model_file = temp_mod, data = model$dataset)
   } else {
     ## Removing tables can only be done for NONMEM datasets
   }

--- a/tests/testthat/test-remove_tables_from_model.R
+++ b/tests/testthat/test-remove_tables_from_model.R
@@ -215,6 +215,29 @@ test_that("returns model unchanged for non-NONMEM models", {
   expect_equal(out, mod)
 })
 
+test_that("preserves datainfo column types when removing tables", {
+  local_pharmr.extra_options()
+  dat <- data.frame(
+    ID = c(1, 1, 1, 2, 2, 2),
+    TIME = c(0, 1, 2, 0, 1, 2),
+    DV = c(0, 10, 5, 0, 12, 6),
+    AMT = c(100, 0, 0, 100, 0, 0),
+    CMT = 1,
+    EVID = c(1, 0, 0, 1, 0, 0),
+    MDV = c(1, 0, 0, 1, 0, 0)
+  )
+  mod <- create_model(
+    route = "iv", data = dat, tables = c("fit", "parameters"), verbose = FALSE
+  )
+
+  out <- remove_tables_from_model(model = mod, file = NULL)
+
+  # datainfo types must be preserved (not reset to "unknown")
+  expect_false(is.null(out$datainfo))
+  expect_equal(out$datainfo[["ID"]]$type, "id")
+  expect_equal(out$datainfo[["DV"]]$type, "dv")
+})
+
 test_that("preserves dataset when removing tables", {
   local_pharmr.extra_options()
   dat <- data.frame(


### PR DESCRIPTION
## Summary

- Simplify `remove_tables_from_model()` by using `create_model_from_file()` instead of a workaround with `set_dataset`/`read_model_from_string`. This properly preserves the dataset and `datainfo` in the returned model object.
- Add a test verifying that `datainfo` column types (e.g. `ID` typed as `"id"`, `DV` typed as `"dv"`) remain intact after removing `$TABLE` records.

## Test plan
- [x] New `datainfo` preservation test passes
- [x] All existing `remove_tables_from_model` tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)