### PR TITLE
Downweigh initial estimates from single-observation subjects

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pharmr.extra
 Title: Extension of pharmr (Pharmpy) functionality
-Version: 0.0.0.9045
+Version: 0.0.0.9046
 Authors@R: c(
     person("Ron", "Keizer", email = "ron@insight-rx.com", role = c("cre", "aut")),
     person("Michael", "McCarthy", email = "michael.mccarthy@insight-rx.com", role = "ctb"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pharmr.extra
 Title: Extension of pharmr (Pharmpy) functionality
-Version: 0.0.0.9044
+Version: 0.0.0.9045
 Authors@R: c(
     person("Ron", "Keizer", email = "ron@insight-rx.com", role = c("cre", "aut")),
     person("Michael", "McCarthy", email = "michael.mccarthy@insight-rx.com", role = "ctb"),

--- a/R/get_initial_estimates_from_data.R
+++ b/R/get_initial_estimates_from_data.R
@@ -56,10 +56,12 @@ get_initial_estimates_from_data <- function(
     }
   }
   pars <- dplyr::bind_rows(pars_list)
-  est <- pars |>
-    dplyr::mutate(dplyr::across(where(is.numeric), ~ ifelse(is.infinite(.), max(.[!is.infinite(.)], na.rm = TRUE), .))) |> # remove all Inf values and replace them with the maximum value for the column
-    dplyr::summarise_all(function(x) signif(mean(x, na.rm=TRUE), 3)) |>
-    as.list()
+  tmp <- pars |>
+    # remove all Inf values and replace them with the maximum value for the column
+    dplyr::mutate(dplyr::across(where(is.numeric), ~ ifelse(is.infinite(.), max(.[!is.infinite(.)], na.rm = TRUE), .))) 
+  est <- apply(tmp[,1:2], 2, function(x) { 
+    signif(weighted.mean(x, w = tmp$weight, na.rm=TRUE), 3)
+  })
   if(n_cmt >= 2) {
     est$QP1 <- est$CL
     est$VP1 <- est$V * 2
@@ -121,7 +123,8 @@ get_initial_estimates_from_individual_data <- function(
   tmp <- tail(obs, 3)
   dose <- dat$AMT[dat$dosenr == dose_nr & dat$EVID == 1]
   est <- c()
-  if(inherits(tmp$TIME, "numeric") && length(unique(tmp$TIME)) > 1) { # two datapoints at least
+  n_points <- length(unique(tmp$TIME))
+  if(inherits(tmp$TIME, "numeric") && n_points > 1) { # two datapoints at least
     fit <- stats::lm(log(DV) ~ TIME, tmp)
     KEL <- -as.numeric(coef(fit)[2])
     if(is.null(KEL) || is.na(KEL)) {
@@ -134,14 +137,16 @@ get_initial_estimates_from_individual_data <- function(
     }
     est$V <- dose / max(obs$DV, na.rm=TRUE)
     est$CL <- KEL * est$V
+    est$weight <- n_points
   } else { # more crude estimation
-    
     if(length(tmp$DV) > 0) {
       est$V <- dose / (max(tmp$DV, na.rm=TRUE) * 5)
-      est$CL <- est$V / 10
+      est$CL <- est$V / 20
+      est$weight <- 0.001 # downweigh this, since very crude estimate. Only use if no subjects with >2 samples available
     } else { # for placebo patients, DV may all be zero or NA so we should not attempt to ballpark V or CL
       est$V <- NA
       est$CL <- NA
+      est$weight <- 0
     }
   }
 

--- a/R/get_initial_estimates_from_data.R
+++ b/R/get_initial_estimates_from_data.R
@@ -58,9 +58,22 @@ get_initial_estimates_from_data <- function(
   pars <- dplyr::bind_rows(pars_list)
   tmp <- pars |>
     # remove all Inf values and replace them with the maximum value for the column
-    dplyr::mutate(dplyr::across(where(is.numeric), ~ ifelse(is.infinite(.), max(.[!is.infinite(.)], na.rm = TRUE), .))) 
-  est <- apply(tmp[,1:2], 2, function(x) { 
-    signif(weighted.mean(x, w = tmp$weight, na.rm=TRUE), 3)
+    dplyr::mutate(dplyr::across(where(is.numeric), ~ ifelse(is.infinite(.), max(.[!is.infinite(.)], na.rm = TRUE), .)))
+
+  safe_weighted_mean <- function(x, w) {
+    ok <- !(is.na(x) | is.na(w) | !is.finite(x) | !is.finite(w))
+    x <- x[ok]
+    w <- w[ok]
+
+    if(length(w) == 0 || sum(w) == 0) {
+      return(NA_real_)
+    }
+
+    weighted.mean(x, w = w)
+  }
+
+  est <- apply(tmp[,1:2], 2, function(x) {
+    signif(safe_weighted_mean(x, w = tmp$weight), 3)
   })
   if(n_cmt >= 2) {
     est$QP1 <- est$CL

--- a/R/get_initial_estimates_from_data.R
+++ b/R/get_initial_estimates_from_data.R
@@ -72,9 +72,9 @@ get_initial_estimates_from_data <- function(
     weighted.mean(x, w = w)
   }
 
-  est <- apply(tmp[,1:2], 2, function(x) {
+  est <- as.list(apply(tmp[,1:2], 2, function(x) {
     signif(safe_weighted_mean(x, w = tmp$weight), 3)
-  })
+  }))
   if(n_cmt >= 2) {
     est$QP1 <- est$CL
     est$VP1 <- est$V * 2

--- a/tests/testthat/test-get_initial_estimates_from_data.R
+++ b/tests/testthat/test-get_initial_estimates_from_data.R
@@ -112,7 +112,7 @@ test_that("get_initial_estimates_from_individual_data works with simple PK data"
   estimates <- get_initial_estimates_from_individual_data(test_data)
   
   # Test that we get the expected parameters
-  expect_named(estimates, c("V", "CL"))
+  expect_named(estimates, c("V", "CL", "weight"))
   
   # Test that values are positive
   expect_true(all(estimates > 0))
@@ -143,7 +143,7 @@ test_that("get_initial_estimates_from_individual_data handles missing data", {
   estimates <- get_initial_estimates_from_individual_data(test_data)
   
   # Test that we still get estimates
-  expect_named(estimates, c("V", "CL"))
+  expect_named(estimates, c("V", "CL", "weight"))
   expect_true(all(estimates > 0))
 })
 
@@ -188,7 +188,7 @@ test_that("get_initial_estimates_from_individual_data handles insufficient data"
   estimates <- get_initial_estimates_from_individual_data(test_data)
   
   # Test that we get an empty result
-  expect_equal(estimates, c(V = 2, CL = 0.2))
+  expect_equal(estimates, c(V = 2, CL = 0.1, weight = 0.001))
 })
 
 test_that("get_initial_estimates_from_individual_data handles two observations at the same timepoint", {
@@ -205,7 +205,7 @@ test_that("get_initial_estimates_from_individual_data handles two observations a
 
   estimates <- get_initial_estimates_from_individual_data(test_data)
 
-  expect_named(estimates, c("V", "CL"))
+  expect_named(estimates, c("V", "CL", "weight"))
   expect_true(all(!is.na(estimates)), label = "estimates must not be NA with duplicate timepoints")
   expect_true(all(estimates > 0),    label = "estimates must be positive")
 })
@@ -225,7 +225,7 @@ test_that("get_initial_estimates_from_individual_data handles absorption-phase o
 
   estimates <- get_initial_estimates_from_individual_data(test_data)
 
-  expect_named(estimates, c("V", "CL"))
+  expect_named(estimates, c("V", "CL", "weight"))
   expect_true(estimates["CL"] > 0, label = "CL must be positive even with absorption-phase-only data")
   expect_true(estimates["V"]  > 0, label = "V must be positive")
 })

--- a/tests/testthat/test-get_initial_estimates_from_data.R
+++ b/tests/testthat/test-get_initial_estimates_from_data.R
@@ -230,6 +230,73 @@ test_that("get_initial_estimates_from_individual_data handles absorption-phase o
   expect_true(estimates["V"]  > 0, label = "V must be positive")
 })
 
+test_that("get_initial_estimates_from_data downweighs single-observation subjects", {
+  # Subject 1 has a well-characterized PK profile (multiple samples) -> reliable
+  # V and CL estimates. Subject 2 has only a single observation -> crude guess.
+  # The pooled estimate should be dominated by subject 1, not the crude guess
+  # from subject 2, because single-observation subjects are downweighted.
+  rich <- data.frame(
+    ID   = 1,
+    TIME = c(0, 1, 4, 8),
+    DV   = c(0, 100, 50, 25),
+    EVID = c(1, 0, 0, 0),
+    MDV  = c(1, 0, 0, 0),
+    AMT  = c(1000, 0, 0, 0)
+  )
+  sparse <- data.frame(
+    ID   = 2,
+    TIME = c(0, 4),
+    DV   = c(0, 50),
+    EVID = c(1, 0),
+    MDV  = c(1, 0),
+    AMT  = c(1000, 0)
+  )
+  combined <- rbind(rich, sparse)
+
+  result_rich_only <- get_initial_estimates_from_data(rich, n_cmt = 1)
+  result_sparse_only <- get_initial_estimates_from_data(sparse, n_cmt = 1)
+  result_combined <- get_initial_estimates_from_data(combined, n_cmt = 1)
+
+  # Sanity check: the crude single-point estimate differs substantially from
+  # the well-characterized one (otherwise this test proves nothing).
+  expect_true(abs(result_sparse_only$CL - result_rich_only$CL) > 0.5)
+
+  # Combined estimate should be very close to the rich-only estimate, because
+  # the single-observation subject carries weight ~0.001.
+  expect_equal(result_combined$V,  result_rich_only$V,  tolerance = 0.01)
+  expect_equal(result_combined$CL, result_rich_only$CL, tolerance = 0.01)
+})
+
+test_that("get_initial_estimates_from_individual_data assigns low weight for single-observation subjects", {
+  # With only one observation we cannot estimate a slope; the function returns
+  # a crude guess that should be flagged with a very low weight so it is
+  # effectively ignored when richer data is available.
+  sparse <- data.frame(
+    ID   = 1,
+    TIME = c(0, 4),
+    DV   = c(0, 50),
+    EVID = c(1, 0),
+    MDV  = c(1, 0),
+    AMT  = c(1000, 0)
+  )
+  rich <- data.frame(
+    ID   = 1,
+    TIME = c(0, 1, 4, 8),
+    DV   = c(0, 100, 50, 25),
+    EVID = c(1, 0, 0, 0),
+    MDV  = c(1, 0, 0, 0),
+    AMT  = c(1000, 0, 0, 0)
+  )
+
+  est_sparse <- get_initial_estimates_from_individual_data(sparse)
+  est_rich   <- get_initial_estimates_from_individual_data(rich)
+
+  expect_true("weight" %in% names(est_sparse))
+  expect_true("weight" %in% names(est_rich))
+  expect_lt(est_sparse[["weight"]], est_rich[["weight"]])
+  expect_lt(est_sparse[["weight"]], 0.01)
+})
+
 test_that("get_initial_estimates_from_data works with CSV filename", {
   test_data <- data.frame(
     ID = c(1, 1, 1, 1),


### PR DESCRIPTION
## Summary
- `get_initial_estimates_from_individual_data` now returns a `weight` field: `n_points` for subjects with a fittable terminal slope, `0.001` for single-observation crude guesses, and `0` for placebo/no-DV subjects.
- `get_initial_estimates_from_data` uses `weighted.mean` so pooled V/CL are dominated by well-characterized subjects when available.
- Also changed the single-obs crude CL fallback from `V/10` to `V/20`.
- Added two tests covering the downweighing behavior (pooled + unit).
- Bumped version to 0.0.0.9045.

## Test plan
- [ ] `devtools::test(filter = "get_initial_estimates_from_data")` passes
- [ ] `devtools::check()` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)