### PR TITLE
Default search_space to IIV(@PK,EXP) for iivsearch

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pharmr.extra
 Title: Extension of pharmr (Pharmpy) functionality
-Version: 0.0.0.9046
+Version: 0.0.0.9047
 Authors@R: c(
     person("Ron", "Keizer", email = "ron@insight-rx.com", role = c("cre", "aut")),
     person("Michael", "McCarthy", email = "michael.mccarthy@insight-rx.com", role = "ctb"),

--- a/R/call_pharmpy_tool.R
+++ b/R/call_pharmpy_tool.R
@@ -136,6 +136,18 @@ call_pharmpy_tool <- function(
     options$n <- NULL
   }
 
+  ## Pharmpy 2.0 regression workaround: run_iivsearch crashes when
+  ## search_space=None (the documented default) because
+  ## ModelFeatures.create(None) raises TypeError. Inject a sensible
+  ## default so the call works out of the box.
+  if(tool == "iivsearch" && is.null(options$search_space)) {
+    options$search_space <- "IIV(@PK,EXP)"
+    if(verbose)
+      cli::cli_alert_info(
+        "No `search_space` provided; defaulting to {.val IIV(@PK,EXP)}"
+      )
+  }
+
   ## prepare arguments for call
   args <- c(
     list(model = model),


### PR DESCRIPTION
## Summary
- Work around a Pharmpy 2.0 regression where `run_iivsearch` crashes when `search_space=None` (the documented default) because `ModelFeatures.create(None)` raises `TypeError`.
- Inject `IIV(@PK,EXP)` as a default `search_space` in `call_pharmpy_tool()` when none is provided, with an informational message when `verbose=TRUE`.
- Bump version to 0.0.0.9047.

## Test plan
- [x] `devtools::test()` passes
- [x] `call_pharmpy_tool(tool = "iivsearch", ...)` runs without specifying `search_space`

🤖 Generated with [Claude Code](https://claude.com/claude-code)