### PR TITLE
Handle missing AMT ('.') safely in run_sim AUC_SS calculation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pharmr.extra
 Title: Extension of pharmr (Pharmpy) functionality
-Version: 0.0.0.9047
+Version: 0.0.0.9048
 Authors@R: c(
     person("Ron", "Keizer", email = "ron@insight-rx.com", role = c("cre", "aut")),
     person("Michael", "McCarthy", email = "michael.mccarthy@insight-rx.com", role = "ctb"),

--- a/R/run_sim.R
+++ b/R/run_sim.R
@@ -261,8 +261,15 @@ calc_pk_variables <- function(
 
     ## Add AUC_SS as CL/dose, if we're simulating a specific regimen
     if(!is.null(regimen) && "CL" %in% names(data)) {
-      data <- data |>
-        dplyr::mutate(AUC_SS = utils::tail(regimen$dose, 1) / .data$CL)
+      suppressWarnings(
+        last_dose <- as.numeric(utils::tail(regimen$dose, 1))
+      )
+      if(!is.na(last_dose) && last_dose > 0) {
+        data <- data |>
+          dplyr::mutate(AUC_SS = last_dose / .data$CL)
+      } else {
+        cli::cli_warn("Could not calculate AUCss, last dose could not be identified.")
+      }
     }
   }
 

--- a/tests/testthat/test-run_sim.R
+++ b/tests/testthat/test-run_sim.R
@@ -320,6 +320,30 @@ test_that("calc_pk_variables: AUC_SS absent when regimen is NULL", {
   expect_false("AUC_SS" %in% names(out))
 })
 
+test_that("calc_pk_variables: warns and skips AUC_SS when last dose is '.' (NONMEM missing)", {
+  dat <- dplyr::mutate(.make_pk_data(), CL = 5)
+  reg <- data.frame(
+    time = c(0, 12), dose = c("100", "."), route = "iv", regimen = "100mg",
+    stringsAsFactors = FALSE
+  )
+  expect_warning(
+    out <- calc_pk_variables(dat, regimen = reg),
+    "Could not calculate AUCss"
+  )
+  expect_false("AUC_SS" %in% names(out))
+})
+
+test_that("calc_pk_variables: AUC_SS computed when dose is numeric-like character", {
+  dat <- dplyr::mutate(.make_pk_data(), CL = 5)
+  reg <- data.frame(
+    time = c(0, 12), dose = c("100", "100"), route = "iv", regimen = "100mg",
+    stringsAsFactors = FALSE
+  )
+  out <- calc_pk_variables(dat, regimen = reg)
+  expect_true("AUC_SS" %in% names(out))
+  expect_equal(unique(out$AUC_SS), 100 / 5)
+})
+
 # ── create_dosing_records() ─────────────────────────────────────────────────
 
 .dose_data2 <- function() data.frame(ID = 1:2, TIME = 0, DV = 0, EVID = 1)


### PR DESCRIPTION
## Summary
- When a dataset uses NONMEM-style `"."` for missing AMT, `tail(regimen$dose, 1)` could return a non-numeric value, breaking `AUC_SS` computation in `calc_pk_variables()`.
- Coerce the last dose to numeric and skip `AUC_SS` with a warning when it cannot be identified.
- Added tests for the `"."` dose case and a numeric-string dose.

## Test plan
- [x] `devtools::test(filter = "run_sim")` passes locally