### PR TITLE
Avoid duplicating existing $EST options when updating estimation_method

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pharmr.extra
 Title: Extension of pharmr (Pharmpy) functionality
-Version: 0.0.0.9048
+Version: 0.0.0.9049
 Authors@R: c(
     person("Ron", "Keizer", email = "ron@insight-rx.com", role = c("cre", "aut")),
     person("Michael", "McCarthy", email = "michael.mccarthy@insight-rx.com", role = "ctb"),

--- a/R/run_nlme.R
+++ b/R/run_nlme.R
@@ -40,6 +40,14 @@
 #' @param estimation_method Optional. Character vector of estimation method(s)
 #' to apply to model. Will remove all existing estimation steps in the model
 #' and update with methods specified in argument.
+#' @param estimation_options Optional. Options for the estimation step(s).
+#' Either a flat named list (applied to the first step) or a named list of
+#' lists keyed by method name for multi-step estimation, e.g.
+#' `list(SAEM = list(NBURN = 500), IMP = list(NITER = 10))`. Options are
+#' merged with package defaults; user values take precedence. Keys that
+#' correspond to pharmpy structured fields (MAXEVAL, NITER, ISAMPLE, PRINT,
+#' AUTO, ETASAMPLES) are routed to the appropriate attribute to avoid
+#' duplication in the rendered `$EST` record.
 #' @param sir_options options for running SIR in covariance step. A list with
 #' options `niter` (number of SIR iterations) and `samples` (number of
 #' samples). Default `NULL` leaves the model unchanged. `samples` should be
@@ -92,6 +100,7 @@ run_nlme <- function(
   save_fit = TRUE,
   save_summary = TRUE,
   estimation_method = NULL,
+  estimation_options = NULL,
   sir_options = NULL,
   auto_stack_encounters = TRUE,
   clean = TRUE,
@@ -117,9 +126,15 @@ run_nlme <- function(
 
   ## Change estimation method, if requested
   if(!is.null(estimation_method)) {
+    per_step_options <- if(!is.null(estimation_options)) {
+      parse_estimation_options(estimation_method, estimation_options)
+    } else {
+      NULL
+    }
     model <- update_estimation_method(
       model,
       estimation_method,
+      per_step_options = per_step_options,
       verbose = verbose
     )
   }

--- a/R/update_estimation_method.R
+++ b/R/update_estimation_method.R
@@ -22,7 +22,8 @@ update_estimation_method <- function(
       any(! estimation_method %in% allowed, na.rm = TRUE)) {
     cli::cli_abort("The requested estimation method was not recognized. Available estimation methods are {allowed} or their lower-case equivalents.")
   }
-  n_existing <- nrow(model$execution_steps$to_dataframe())
+  current_est <- model$execution_steps$to_dataframe()
+  n_existing <- nrow(current_est)
   n_new <- length(estimation_method)
   if(verbose) {
     steps_str <- paste(estimation_method, collapse = " -> ")
@@ -32,14 +33,22 @@ update_estimation_method <- function(
   ## preserve any step-level options (e.g. tool_options), and
   ## add_estimation_step for any additional steps beyond what already exists.
   for(i in seq_along(estimation_method)) {
-    ## Compute tool_options for this step (only when per_step_options is provided)
-    if(!is.null(per_step_options) && i <= length(per_step_options)) {
-      step_opts <- per_step_options[[i]]
+    step_opts <- if(!is.null(per_step_options) && i <= length(per_step_options)) {
+      per_step_options[[i]]
     } else {
-      step_opts <- list()
+      list()
     }
-    tool_options_i <- get_estimation_options(tool, tolower(estimation_method[i]), list())
     if(i <= n_existing) {
+      existing_method <- toupper(as.character(current_est$method[i]))
+      requested_method <- estimation_method[i]
+      ## Case 1: method matches and no user overrides — leave $EST untouched.
+      if(identical(existing_method, requested_method) && length(step_opts) == 0) {
+        if(verbose) {
+          cli::cli_alert_info("Step {i}: {requested_method} already set, no overrides provided; leaving $EST unchanged.")
+        }
+        next
+      }
+
       cov_record <- if(tool == "nonmem" && has_covariance_record(model)) {
         get_covariance_record(model)
       } else {
@@ -48,16 +57,67 @@ update_estimation_method <- function(
       # Save $TABLE records: pharmpy's set_estimation_step() may corrupt them
       # by appending predictions/residuals to the last $TABLE in wrong position
       saved_tables <- if(tool == "nonmem") get_table_records(model) else NULL
-      current_est <- model$execution_steps$to_dataframe()
-      if(!is.null(current_est$maximum_evaluations)) {
-        tool_options_i$MAXEVAL <- NULL # cannot be set again
+
+      ## Build desired_opts
+      ## - if method differs: defaults overridden by user step_opts
+      ## - if method matches: user step_opts only (don't re-apply defaults)
+      if(identical(existing_method, requested_method)) {
+        desired_opts <- step_opts
+      } else {
+        desired_opts <- get_estimation_options(tool, tolower(requested_method), step_opts)
       }
-      model <- pharmr::set_estimation_step(
-        model,
-        method = estimation_method[i],
-        idx = i - 1L,  # 0-indexed
-        tool_options = tool_options_i
+
+      ## Existing tool_options dict for this step, preserved unless overridden
+      existing_tool_opts <- current_est$tool_options[[i]]
+      if(is.null(existing_tool_opts)) existing_tool_opts <- list()
+      existing_tool_opts <- as.list(existing_tool_opts)
+
+      ## Split desired_opts into structured kwargs vs tool_options.
+      structured_kwargs <- list()
+      tool_options_update <- list()
+      for(key in names(desired_opts)) {
+        up_key <- toupper(key)
+        if(up_key %in% names(STRUCTURED_OPTION_MAP)) {
+          map <- STRUCTURED_OPTION_MAP[[up_key]]
+          val <- desired_opts[[key]]
+          if(identical(map$type, "integer")) {
+            val <- as.integer(val)
+          } else if(identical(map$type, "logical")) {
+            val <- as.logical(val)
+          }
+          structured_kwargs[[map$field]] <- val
+        } else {
+          tool_options_update[[up_key]] <- desired_opts[[key]]
+        }
+      }
+
+      ## Final tool_options: start from existing, apply non-structured updates.
+      final_tool_options <- existing_tool_opts
+      for(k in names(tool_options_update)) {
+        final_tool_options[[k]] <- tool_options_update[[k]]
+      }
+      ## Strip any structured-field key from final_tool_options to prevent
+      ## the pharmpy writer from emitting the option twice (it emits
+      ## structured fields AND all tool_options without deduplication).
+      for(struct_opt in names(STRUCTURED_OPTION_MAP)) {
+        final_tool_options[[struct_opt]] <- NULL
+      }
+      ## Coerce remaining values to character (matches get_estimation_options).
+      for(k in names(final_tool_options)) {
+        final_tool_options[[k]] <- as.character(final_tool_options[[k]])
+      }
+
+      call_args <- c(
+        list(
+          model = model,
+          method = requested_method,
+          idx = i - 1L
+        ),
+        structured_kwargs,
+        list(tool_options = final_tool_options)
       )
+      model <- do.call(pharmr::set_estimation_step, call_args)
+
       if(!is.null(cov_record)) { # the previous command may reset the COV record
         model <- update_covariance_record(model, cov_record)
       }
@@ -65,6 +125,7 @@ update_estimation_method <- function(
         model <- restore_table_records(model, saved_tables)
       }
     } else {
+      tool_options_i <- get_estimation_options(tool, tolower(estimation_method[i]), step_opts)
       model <- pharmr::add_estimation_step(
         model,
         method = estimation_method[i],
@@ -89,3 +150,16 @@ update_estimation_method <- function(
   }
   model
 }
+
+## Mapping from NONMEM $EST option keys to pharmpy EstimationStep structured
+## fields. Keys in this map are emitted by pharmpy as first-class attributes
+## (separate from the tool_options dict); passing them via tool_options in
+## addition would cause duplication in the rendered $EST record.
+STRUCTURED_OPTION_MAP <- list(
+  MAXEVAL    = list(field = "maximum_evaluations",    type = "integer"),
+  NITER      = list(field = "niter",                  type = "integer"),
+  ISAMPLE    = list(field = "isample",                type = "integer"),
+  PRINT      = list(field = "keep_every_nth_iter",    type = "integer"),
+  AUTO       = list(field = "auto",                   type = "integer"),
+  ETASAMPLES = list(field = "individual_eta_samples", type = "logical")
+)

--- a/man/run_nlme.Rd
+++ b/man/run_nlme.Rd
@@ -18,6 +18,7 @@ run_nlme(
   save_fit = TRUE,
   save_summary = TRUE,
   estimation_method = NULL,
+  estimation_options = NULL,
   sir_options = NULL,
   auto_stack_encounters = TRUE,
   clean = TRUE,
@@ -73,6 +74,15 @@ Default is \code{TRUE}. Will use current folder, and save as
 \item{estimation_method}{Optional. Character vector of estimation method(s)
 to apply to model. Will remove all existing estimation steps in the model
 and update with methods specified in argument.}
+
+\item{estimation_options}{Optional. Options for the estimation step(s).
+Either a flat named list (applied to the first step) or a named list of
+lists keyed by method name for multi-step estimation, e.g.
+\code{list(SAEM = list(NBURN = 500), IMP = list(NITER = 10))}. Options are
+merged with package defaults; user values take precedence. Keys that
+correspond to pharmpy structured fields (MAXEVAL, NITER, ISAMPLE, PRINT,
+AUTO, ETASAMPLES) are routed to the appropriate attribute to avoid
+duplication in the rendered \verb{$EST} record.}
 
 \item{sir_options}{options for running SIR in covariance step. A list with
 options \code{niter} (number of SIR iterations) and \code{samples} (number of

--- a/tests/testthat/test-update_estimation_method.R
+++ b/tests/testthat/test-update_estimation_method.R
@@ -301,3 +301,128 @@ test_that("$TABLE preserved with multiple estimation steps", {
   expect_equal(length(tables_after), length(tables_before))
   expect_equal(tables_after, tables_before)
 })
+
+# -- $EST option deduplication and override tests ----------------------------
+
+# Helper: a base model whose $EST already has all the SAEM structured options
+# (the reproducer scenario) plus a non-structured tool_option (NBURN).
+make_saem_model_with_full_opts <- function(niter = 1000) {
+  code <- paste0(
+    "$PROBLEM Test\n",
+    "$INPUT ID TIME DV AMT EVID MDV\n",
+    "$DATA data.csv IGNORE=@\n",
+    "$SUBROUTINES ADVAN1 TRANS2\n",
+    "$PK\n",
+    "MU_1=LOG(THETA(1))\nMU_2=LOG(THETA(2))\n",
+    "CL=EXP(MU_1+ETA(1))\nV=EXP(MU_2+ETA(2))\nS1=V\n",
+    "$ERROR\nY=F+EPS(1)\n",
+    "$THETA (0,10) ; POP_CL\n$THETA (0,50) ; POP_V\n",
+    "$OMEGA 0.1\n$OMEGA 0.1\n$SIGMA 0.1\n",
+    "$ESTIMATION METHOD=SAEM INTER MAXEVAL=99999 PRINT=5 NBURN=500 ",
+    "NITER=", niter, " ISAMPLE=2\n"
+  )
+  pharmr::read_model_from_string(code)
+}
+
+# Helper: extract the $EST line (first occurrence) from model code.
+get_est_line <- function(code) {
+  lines <- strsplit(code, "\n", fixed = TRUE)[[1]]
+  est <- grep("^\\$EST", lines, value = TRUE)
+  if (length(est) == 0) "" else est[1]
+}
+
+# Helper: count how many times a given option token appears in the $EST line.
+count_opt <- function(code, opt) {
+  est <- get_est_line(code)
+  length(gregexpr(paste0("\\b", opt, "\\b"), est)[[1]] |>
+    (\(x) x[x > 0])())
+}
+
+test_that("same-method update does not duplicate structured options", {
+  local_pharmr.extra_options()
+  mod <- make_saem_model_with_full_opts()
+  updated <- update_estimation_method(mod, "SAEM", verbose = FALSE)
+  est <- get_est_line(updated$code)
+
+  for (opt in c("MAXEVAL", "NITER", "ISAMPLE", "PRINT", "NBURN")) {
+    expect_equal(
+      count_opt(updated$code, opt), 1L,
+      info = paste("option duplicated:", opt, "in:", est)
+    )
+  }
+})
+
+test_that("same-method, no overrides, leaves $EST unchanged byte-for-byte", {
+  local_pharmr.extra_options()
+  mod <- make_saem_model_with_full_opts()
+  before <- get_est_line(mod$code)
+  updated <- update_estimation_method(mod, "SAEM", verbose = FALSE)
+  after <- get_est_line(updated$code)
+  expect_equal(after, before)
+})
+
+test_that("user override updates an existing structured option", {
+  local_pharmr.extra_options()
+  mod <- make_saem_model_with_full_opts(niter = 100)
+  updated <- update_estimation_method(
+    mod, "SAEM",
+    per_step_options = list(list(NITER = 200)),
+    verbose = FALSE
+  )
+  est <- get_est_line(updated$code)
+  expect_match(est, "NITER=200")
+  expect_false(grepl("NITER=100", est))
+  expect_equal(count_opt(updated$code, "NITER"), 1L)
+})
+
+test_that("user override updates an existing non-structured tool_option", {
+  local_pharmr.extra_options()
+  mod <- make_saem_model_with_full_opts()
+  updated <- update_estimation_method(
+    mod, "SAEM",
+    per_step_options = list(list(NBURN = 700)),
+    verbose = FALSE
+  )
+  est <- get_est_line(updated$code)
+  expect_match(est, "NBURN=700")
+  expect_false(grepl("NBURN=500", est))
+  expect_equal(count_opt(updated$code, "NBURN"), 1L)
+})
+
+test_that("method change applies defaults plus preserves non-structured opts", {
+  local_pharmr.extra_options()
+  # Start FOCE with NOABORT (a non-structured tool_option) set
+  code <- paste0(
+    "$PROBLEM Test\n$INPUT ID TIME DV AMT EVID MDV\n",
+    "$DATA data.csv IGNORE=@\n$SUBROUTINES ADVAN1 TRANS2\n",
+    "$PK\nCL=THETA(1)\nV=THETA(2)\nS1=V\n$ERROR\nY=F+EPS(1)\n",
+    "$THETA (0,10)\n$THETA (0,50)\n$OMEGA 0.1\n$SIGMA 0.1\n",
+    "$ESTIMATION METHOD=COND INTER MAXEVAL=9999 NOABORT\n"
+  )
+  mod <- pharmr::read_model_from_string(code)
+  updated <- update_estimation_method(mod, "SAEM", verbose = FALSE)
+  est <- get_est_line(updated$code)
+  expect_match(est, "METHOD=SAEM")
+  expect_match(est, "NOABORT")
+  # Defaults applied exactly once
+  expect_equal(count_opt(updated$code, "NITER"), 1L)
+  expect_equal(count_opt(updated$code, "ISAMPLE"), 1L)
+})
+
+test_that("arbitrary option passthrough works without duplication", {
+  local_pharmr.extra_options()
+  mod <- make_saem_model_with_full_opts()
+  updated <- update_estimation_method(
+    mod, "SAEM",
+    per_step_options = list(list(LIKELIHOOD = "", NBURN = 700)),
+    verbose = FALSE
+  )
+  est <- get_est_line(updated$code)
+  expect_match(est, "LIKELIHOOD")
+  expect_match(est, "NBURN=700")
+  expect_equal(count_opt(updated$code, "LIKELIHOOD"), 1L)
+  expect_equal(count_opt(updated$code, "NBURN"), 1L)
+  # NITER not overridden, existing value preserved
+  expect_match(est, "NITER=1000")
+  expect_equal(count_opt(updated$code, "NITER"), 1L)
+})


### PR DESCRIPTION
## Summary

- Fixes `update_estimation_method()` producing invalid NONMEM control streams (`OPTION SET MORE THAN ONCE`) when the existing `$EST` record already contained SAEM-style options. Pharmpy promotes `NITER`, `ISAMPLE`, `MAXEVAL`, `PRINT`, `AUTO`, `ETASAMPLES` to structured fields and emits them *plus* every `tool_options` key without deduplicating — our package defaults ended up in both channels. Structured options are now routed to their pharmpy kwargs so they can appear only once.
- Adds per-step decision logic: same method + no user overrides → no-op; same method + overrides → apply only overrides; method change → defaults merged with overrides, existing non-structured options preserved.
- Exposes `estimation_options` on `run_nlme()` and fixes a latent bug where `per_step_options` were silently dropped inside `update_estimation_method()`.

## Test plan

- [x] New unit tests in `test-update_estimation_method.R` covering: no duplication on same-method update, byte-exact no-op, structured override (`NITER=100 → NITER=200`), non-structured override (`NBURN`), method-change preservation, and arbitrary-option passthrough.
- [x] `devtools::test(filter = "update_estimation_method")` — 59/59 pass.
- [x] `devtools::test(filter = "run_nlme")` — 37/37 pass.
- [x] Full suite — 1523 pass; 2 pre-existing `test-create_model.R` failures on `main` unrelated to this change.
- [x] End-to-end reproducer (`~/projects/debug/20260422_misc/16_32_43_2026_04_22_poppk_run.R`): NM-TRAN now accepts the generated `.mod`.

## Out of scope

`create_model.R` uses the same `set_estimation_step` pattern but only on freshly built pharmpy models whose default `$EST` lacks the problematic options — no real-world duplication, left for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)