### PR TITLE
Fix set_compartment_scale silently dropping S<n> when missing

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -19,7 +19,12 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: ubuntu-latest,   r: 'release'}
+          # Pinned to R 4.5 because qs (a transitive dep of nlmixr2est) is
+          # archived from CRAN and its source no longer compiles against
+          # R 4.6+ (LEVELS, Rf_allocSExp etc. removed). P3M has qs binaries
+          # for R 4.5 but not R 4.6. Revert to 'release' once the dep chain
+          # drops qs or upstream restores R 4.6 compatibility.
+          - {os: ubuntu-latest,   r: '4.5'}
           #- {os: macos-latest,   r: 'release'}
           #- {os: windows-latest, r: 'release'}
           #- {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
@@ -48,15 +53,9 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           pak-version: devel
-          # qs has been archived from CRAN, so the default P3M `latest`
-          # snapshot returns 404. nlmixr2est still requires qs, and the
-          # qsbase/qs HEAD source no longer compiles against R 4.5+. Pin a
-          # dated P3M snapshot that still has the qs binary as a fallback.
-          extra-repositories: |
-            https://packagemanager.posit.co/cran/__linux__/noble/2025-09-01
           extra-packages: |
             any::rcmdcheck
-            qs
+            qsbase/qs
             cran/lotri
             cran/rxode2
             cran/nlmixr2est

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -50,7 +50,6 @@ jobs:
           pak-version: devel
           extra-packages: |
             any::rcmdcheck
-            qsbase/qs
             cran/lotri
             cran/rxode2
             cran/nlmixr2est

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -48,8 +48,15 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           pak-version: devel
+          # qs has been archived from CRAN, so the default P3M `latest`
+          # snapshot returns 404. nlmixr2est still requires qs, and the
+          # qsbase/qs HEAD source no longer compiles against R 4.5+. Pin a
+          # dated P3M snapshot that still has the qs binary as a fallback.
+          extra-repositories: |
+            https://packagemanager.posit.co/cran/__linux__/noble/2025-09-01
           extra-packages: |
             any::rcmdcheck
+            qs
             cran/lotri
             cran/rxode2
             cran/nlmixr2est

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -18,17 +18,17 @@ jobs:
 
       - uses: r-lib/actions/setup-r@v2
         with:
+          # Pinned to R 4.5 — see R-CMD-check.yaml for rationale (qs dep
+          # is archived and its source doesn't compile against R 4.6+).
+          r-version: '4.5'
           use-public-rspm: true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          # See R-CMD-check.yaml for why a dated P3M snapshot is pinned.
-          extra-repositories: |
-            https://packagemanager.posit.co/cran/__linux__/noble/2025-09-01
           extra-packages: |
             any::covr
             any::xml2
-            qs
+            qsbase/qs
             cran/lotri
             cran/rxode2
             cran/nlmixr2est

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -22,9 +22,13 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
+          # See R-CMD-check.yaml for why a dated P3M snapshot is pinned.
+          extra-repositories: |
+            https://packagemanager.posit.co/cran/__linux__/noble/2025-09-01
           extra-packages: |
             any::covr
             any::xml2
+            qs
             cran/lotri
             cran/rxode2
             cran/nlmixr2est

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -25,7 +25,6 @@ jobs:
           extra-packages: |
             any::covr
             any::xml2
-            qsbase/qs
             cran/lotri
             cran/rxode2
             cran/nlmixr2est

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pharmr.extra
 Title: Extension of pharmr (Pharmpy) functionality
-Version: 0.0.0.9049
+Version: 0.0.0.9050
 Authors@R: c(
     person("Ron", "Keizer", email = "ron@insight-rx.com", role = c("cre", "aut")),
     person("Michael", "McCarthy", email = "michael.mccarthy@insight-rx.com", role = "ctb"),

--- a/R/set_compartment_scale.R
+++ b/R/set_compartment_scale.R
@@ -55,7 +55,27 @@ set_compartment_scale <- function(
   code <- stringr::str_split(model$code, "\\n")[[1]]
   pattern <- paste0("^S", compartment, " *=")
   idx <- grep(pattern, code)[1]
-  code[idx] <- new_expr
+  if (is.na(idx)) {
+    ## No existing S<n> assignment — insert one just before the $ERROR block
+    ## (or at end of code if $ERROR is absent).
+    error_idx <- grep("^\\$ERROR", code)[1]
+    insert_at <- if (is.na(error_idx)) length(code) + 1L else error_idx
+    code <- append(code, new_expr, after = insert_at - 1L)
+
+    ## When pharmpy writes IPRED manually as `A(<n>)/<volume_var>` in $ERROR,
+    ## NONMEM's S<n> scaling is bypassed. Rewrite that division to use S<n> so
+    ## the new scaling actually affects the predicted concentration.
+    ipred_idx <- grep("^\\s*IPRED\\s*=", code)
+    if (length(ipred_idx) > 0) {
+      code[ipred_idx] <- gsub(
+        paste0("/\\s*", expr_var, "\\b"),
+        paste0("/S", compartment),
+        code[ipred_idx]
+      )
+    }
+  } else {
+    code[idx] <- new_expr
+  }
   new_code <- paste0(code, collapse = "\n")
 
   ## Reload model from file

--- a/tests/testthat/test-set_compartment_scale.R
+++ b/tests/testthat/test-set_compartment_scale.R
@@ -207,18 +207,26 @@ test_that("set_compartment_scale infers compartment 1 for ADVAN 1, 3, 11", {
 })
 
 test_that("set_compartment_scale adds new scaling when none exists", {
-  model <- list(code = "other code\nmore code")
+  model <- list(code = paste(
+    "$PK",
+    "VC = THETA(2)",
+    "$ERROR",
+    "IPRED = A(2)/VC",
+    "Y = IPRED + EPS(1)",
+    sep = "\n"
+  ))
 
   mockery::stub(set_compartment_scale, "get_compartment_scale", NULL)
+  captured_code <- NULL
   mockery::stub(set_compartment_scale, "pharmr::read_model_from_string",
     function(code) {
-      grepl("S2 = V/1000", code, fixed = TRUE)
+      captured_code <<- code
       return(list(code = code))
     })
   mockery::stub(set_compartment_scale, "scale_initial_estimates_pk",
     function(model, scale) model)
   mockery::stub(set_compartment_scale, "find_pk_parameter",
-    function(model, scale) "V")
+    function(parameter, model) "VC")
 
   expect_message(
     result <- set_compartment_scale(
@@ -228,6 +236,11 @@ test_that("set_compartment_scale adds new scaling when none exists", {
     ),
     "No scaling specified for compartment 2, adding scale"
   )
+  ## S2 line is inserted before $ERROR
+  expect_true(grepl("S2 = VC/1000", captured_code, fixed = TRUE))
+  ## IPRED is rewritten to use S2 instead of VC so scaling takes effect
+  expect_true(grepl("IPRED = A(2)/S2", captured_code, fixed = TRUE))
+  expect_false(grepl("IPRED = A(2)/VC", captured_code, fixed = TRUE))
 })
 
 test_that("set_compartment_scale updates existing scaling", {


### PR DESCRIPTION
## Summary
- `set_compartment_scale()` silently failed to add an `S<n>` line when the model had no existing one — `grep(...)[1]` returned `NA`, and `code[NA] <- new_expr` was a silent no-op, so models built with `scale_observations = 1000` were reloaded unchanged.
- Now the new `S<n> = <volume>/<scale>` line is inserted just before `$ERROR`. Additionally, when pharmpy writes `IPRED = A(<n>)/<volume_var>` directly in `$ERROR` (which bypasses NONMEM's S<n> scaling), the divisor is rewritten to `S<n>` so the scale actually affects the predicted concentration.
- Fixed the corresponding unit test, which had a bare `grepl(...)` without `expect_true(...)` and was therefore not asserting anything; replaced with assertions that verify both the inserted `S<n>` line and the rewritten `IPRED`.
- Triggered by a reprex with `pharmr::create_basic_pk_model` (the default `use_template = FALSE` path in `create_model()`); template-based models already had an `S<n>` line so they never hit the buggy path.

## Test plan
- [x] `devtools::test(filter = "set_compartment_scale")` — all 29 tests pass locally
- [ ] CI `R-CMD-check` green
- [ ] Re-run the original reprex and confirm the generated `.mod` now contains `S2 = VC/1000` in `$PK` and `IPRED = A(2)/S2` in `$ERROR`

🤖 Generated with [Claude Code](https://claude.com/claude-code)