### PR TITLE
Surface NONMEM errors when run_sim() produces no output

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pharmr.extra
 Title: Extension of pharmr (Pharmpy) functionality
-Version: 0.0.0.9048
+Version: 0.0.0.9049
 Authors@R: c(
     person("Ron", "Keizer", email = "ron@insight-rx.com", role = c("cre", "aut")),
     person("Michael", "McCarthy", email = "michael.mccarthy@insight-rx.com", role = "ctb"),

--- a/R/run_sim.R
+++ b/R/run_sim.R
@@ -178,6 +178,18 @@ run_sim <- function(
       verbose = FALSE
     )
 
+    ## Detect silent NONMEM failures: pharmpy/run_nlme do not raise when a
+    ## simulation produces no output table, so we check here and surface the
+    ## .lst error before the next regimen overwrites the run folder.
+    res_tables <- attr(results, "tables")
+    sim_tab <- if(length(res_tables) > 0) res_tables[[1]] else NULL
+    if(is.null(sim_tab) || nrow(sim_tab) == 0) {
+      abort_on_failed_sim(
+        regimen_label = reg_label,
+        fit_folder = file.path(getwd(), id)
+      )
+    }
+
     ## post-processing
     if(update_table) {
       if(add_pk_variables) {
@@ -446,8 +458,57 @@ fill_missing <- function(x, default = NA) {
   }
 }
 
+#' Abort with the NONMEM error from .lst when a simulation produced no output
+#'
+#' @param regimen_label label of the regimen that failed
+#' @param fit_folder NONMEM run folder for this regimen
+#' @noRd
+abort_on_failed_sim <- function(regimen_label, fit_folder) {
+  lst_path <- file.path(fit_folder, "run.lst")
+  stderr_path <- file.path(fit_folder, "stderr")
+  lst <- if(file.exists(lst_path)) readLines(lst_path, warn = FALSE) else character(0)
+  err <- if(file.exists(stderr_path)) readLines(stderr_path, warn = FALSE) else character(0)
+
+  ## Try to find a known NONMEM error marker and grab nearby context.
+  ## Otherwise fall back to the tail of the .lst file.
+  markers <- c(
+    "AN ERROR WAS FOUND IN THE CONTROL STATEMENTS",
+    "MESSAGE ISSUED FROM NMTRAN",
+    "PROGRAM TERMINATED BY OBJ",
+    "PRED EXIT CODE",
+    "ERROR IN",
+    "NUMERICAL DIFFICULTIES"
+  )
+  marker_hit <- which(stringr::str_detect(lst, paste(markers, collapse = "|")))
+  if(length(marker_hit) > 0) {
+    first <- marker_hit[1]
+    snippet <- lst[seq(first, min(length(lst), first + 25))]
+  } else if(length(lst) > 0) {
+    snippet <- utils::tail(lst, 30)
+  } else {
+    snippet <- character(0)
+  }
+
+  ## Escape braces so cli/glue doesn't interpret raw NONMEM output as
+  ## interpolation expressions.
+  esc <- function(x) gsub("}", "}}", gsub("{", "{{", x, fixed = TRUE), fixed = TRUE)
+
+  msg <- c(
+    "NONMEM simulation produced no output for regimen {.val {regimen_label}}.",
+    i = "Run folder: {.path {fit_folder}}"
+  )
+  if(length(snippet) > 0) {
+    msg <- c(msg, "NONMEM output (run.lst):", paste0("  ", esc(snippet)))
+  } else if(length(err) > 0) {
+    msg <- c(msg, "NONMEM stderr:", paste0("  ", esc(utils::tail(err, 20))))
+  } else {
+    msg <- c(msg, x = "No run.lst or stderr found in run folder.")
+  }
+  cli::cli_abort(msg, class = "pharmr_extra_sim_failed")
+}
+
 #' Create a dictionary from given specs and default dictionary as fallback
-#' 
+#'
 parse_data_dictionary <- function(
   dictionary,
   default = list(

--- a/tests/testthat/test-abort_on_failed_sim.R
+++ b/tests/testthat/test-abort_on_failed_sim.R
@@ -1,0 +1,64 @@
+test_that("aborts with class pharmr_extra_sim_failed when run folder is empty", {
+  tmp <- withr::local_tempdir()
+  expect_error(
+    abort_on_failed_sim("regimen A", tmp),
+    class = "pharmr_extra_sim_failed"
+  )
+})
+
+test_that("includes snippet starting at NONMEM error marker in run.lst", {
+  tmp <- withr::local_tempdir()
+  writeLines(
+    c(
+      "preamble line",
+      " AN ERROR WAS FOUND IN THE CONTROL STATEMENTS.",
+      " (DATA ITEM 5): SS NOT DEFINED",
+      "trailing"
+    ),
+    file.path(tmp, "run.lst")
+  )
+  err <- tryCatch(
+    abort_on_failed_sim("regimen B", tmp),
+    error = function(e) e
+  )
+  msg <- conditionMessage(err)
+  expect_match(msg, "AN ERROR WAS FOUND IN THE CONTROL STATEMENTS")
+  expect_match(msg, "SS NOT DEFINED")
+  expect_match(msg, "regimen B")
+})
+
+test_that("falls back to .lst tail when no known marker is present", {
+  tmp <- withr::local_tempdir()
+  lines <- c(paste0("line", 1:50), "FINAL TAIL LINE")
+  writeLines(lines, file.path(tmp, "run.lst"))
+  err <- tryCatch(
+    abort_on_failed_sim("regimen C", tmp),
+    error = function(e) e
+  )
+  expect_match(conditionMessage(err), "FINAL TAIL LINE")
+})
+
+test_that("braces in NONMEM output do not break glue interpolation", {
+  tmp <- withr::local_tempdir()
+  writeLines(
+    c("PRED EXIT CODE = 1", "weird {token}", "x{y}"),
+    file.path(tmp, "run.lst")
+  )
+  err <- tryCatch(
+    abort_on_failed_sim("regimen D", tmp),
+    error = function(e) e
+  )
+  msg <- conditionMessage(err)
+  expect_match(msg, "PRED EXIT CODE")
+  expect_match(msg, "\\{token\\}", perl = TRUE)
+})
+
+test_that("falls back to stderr when run.lst is absent", {
+  tmp <- withr::local_tempdir()
+  writeLines(c("nmfe error: cannot find data file"), file.path(tmp, "stderr"))
+  err <- tryCatch(
+    abort_on_failed_sim("regimen E", tmp),
+    error = function(e) e
+  )
+  expect_match(conditionMessage(err), "cannot find data file")
+})


### PR DESCRIPTION
## Summary
- When NONMEM dies during a simulation, the table file is never written, but pharmpy/`run_nlme()` don't raise. `run_sim()` was emitting a quiet warning and returning a 0-row data.frame — callers (the AI agent in particular) had no signal of the underlying failure and would retry blindly.
- After each per-regimen `run_nlme()`, check whether a simulation table came back. If not, read `run.lst` (with `stderr` as fallback), extract the relevant error context, and abort with class `pharmr_extra_sim_failed`.
- Marker-driven snippet extraction picks the first match of common NONMEM failure phrases (`AN ERROR WAS FOUND IN THE CONTROL STATEMENTS`, `MESSAGE ISSUED FROM NMTRAN`, `PROGRAM TERMINATED BY OBJ`, `PRED EXIT CODE`, `ERROR IN`, `NUMERICAL DIFFICULTIES`); falls back to the tail of the `.lst` if no marker hits.

## Test plan
- [x] `devtools::load_all()` succeeds
- [x] Smoke test of `abort_on_failed_sim()` with (a) empty run folder, (b) `.lst` containing an NM-TRAN error, (c) `.lst` lines containing `{}` (glue-safety) — all produce informative messages and the right condition class
- [x] CI: `R-CMD-check` on Ubuntu
- [x] Local sanity check on a real model where NONMEM intentionally fails (e.g. malformed `$DATA`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)