### PR TITLE
Handle data.frame input in run_nlme() and fix model tempfile extension

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pharmr.extra
 Title: Extension of pharmr (Pharmpy) functionality
-Version: 0.0.0.9051
+Version: 0.0.0.9052
 Authors@R: c(
     person("Ron", "Keizer", email = "ron@insight-rx.com", role = c("cre", "aut")),
     person("Michael", "McCarthy", email = "michael.mccarthy@insight-rx.com", role = "ctb"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pharmr.extra
 Title: Extension of pharmr (Pharmpy) functionality
-Version: 0.0.0.9054
+Version: 0.0.0.9055
 Authors@R: c(
     person("Ron", "Keizer", email = "ron@insight-rx.com", role = c("cre", "aut")),
     person("Michael", "McCarthy", email = "michael.mccarthy@insight-rx.com", role = "ctb"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pharmr.extra
 Title: Extension of pharmr (Pharmpy) functionality
-Version: 0.0.0.9052
+Version: 0.0.0.9053
 Authors@R: c(
     person("Ron", "Keizer", email = "ron@insight-rx.com", role = c("cre", "aut")),
     person("Michael", "McCarthy", email = "michael.mccarthy@insight-rx.com", role = "ctb"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pharmr.extra
 Title: Extension of pharmr (Pharmpy) functionality
-Version: 0.0.0.9053
+Version: 0.0.0.9054
 Authors@R: c(
     person("Ron", "Keizer", email = "ron@insight-rx.com", role = c("cre", "aut")),
     person("Michael", "McCarthy", email = "michael.mccarthy@insight-rx.com", role = "ctb"),

--- a/R/create_sim_dataset.R
+++ b/R/create_sim_dataset.R
@@ -141,7 +141,7 @@ create_sim_dataset <- function(
     n_input  <- length(idx$nonmem_name)
     addl_cols <- n_data - n_input
     if(addl_cols > 0) {
-      names(input_data)[seq_len(n_input)] <- idx$nonmem_name
+      names(input_data) <- c(idx$nonmem_name, paste0("EXTRA_", seq(addl_cols)))
       cli::cli_warn("Number of columns for input dataset is higher than number of columns in $INPUT. Please check dataset and $INPUT correctness. Will continue, assuming extra columns are not needed.")
     } else if (addl_cols < 0) {
       cli::cli_abort("Number of columns for input dataset is lower than number of columns in $INPUT. Please check dataset and $INPUT. Cannot continue creating dataset.")

--- a/R/get_tables_in_model_code.R
+++ b/R/get_tables_in_model_code.R
@@ -7,9 +7,10 @@
 #' 
 #' @export
 get_tables_in_model_code <- function(code) {
+  if(length(code) == 0) return(character(0))
   txt <- stringr::str_replace_all(code, "\\n", " ")
   tables <- stringr::str_match_all(
-    txt, 
+    txt,
     "\\$TABLE\\s+(?:(?!\\$).)*?FILE=([^\\s]+)"
   )[[1]][,2]
   tables

--- a/R/remove_tables_from_model.R
+++ b/R/remove_tables_from_model.R
@@ -29,7 +29,15 @@ remove_tables_from_model <- function(
     writeLines(code_without_tables, temp_mod)
     model <- create_model_from_file(model_file = temp_mod)
     if(!is.null(original_dataset)) {
-      model <- pharmr::set_dataset(model, original_dataset)
+      ## `datatype = "nonmem"` keeps datainfo column types (id, dv, etc.)
+      ## inferred from $INPUT — without it they get reset to "unknown".
+      ## Write the dataset to a temp CSV so pharmr::set_dataset() takes the
+      ## path-based code path (mirrors create_model_from_file()).
+      temp_csv <- tempfile(pattern = "data_", fileext = ".csv")
+      write.csv(original_dataset, temp_csv, quote = FALSE, row.names = FALSE)
+      model <- pharmr::set_dataset(
+        model, path_or_df = temp_csv, datatype = "nonmem"
+      )
     }
   } else {
     ## Removing tables can only be done for NONMEM datasets

--- a/R/remove_tables_from_model.R
+++ b/R/remove_tables_from_model.R
@@ -20,11 +20,17 @@ remove_tables_from_model <- function(
       return(model)
     }
 
-    ## Reread model without tables
+    ## Reread model without tables. We deliberately don't pass `data` to
+    ## avoid Pharmpy re-parsing it; instead, reattach the original dataset
+    ## afterwards so downstream callers see the same `$dataset`.
+    original_dataset <- model$dataset
     code_without_tables <- remove_table_sections(model$code, file = file)
     temp_mod <- tempfile(pattern = "tmp_mod_", fileext = '.mod')
     writeLines(code_without_tables, temp_mod)
     model <- create_model_from_file(model_file = temp_mod)
+    if(!is.null(original_dataset)) {
+      model <- pharmr::set_dataset(model, original_dataset)
+    }
   } else {
     ## Removing tables can only be done for NONMEM datasets
   }

--- a/R/remove_tables_from_model.R
+++ b/R/remove_tables_from_model.R
@@ -24,7 +24,7 @@ remove_tables_from_model <- function(
     code_without_tables <- remove_table_sections(model$code, file = file)
     temp_mod <- tempfile(pattern = "tmp_mod_", fileext = '.mod')
     writeLines(code_without_tables, temp_mod)
-    model <- create_model_from_file(model_file = temp_mod, data = model$dataset)
+    model <- create_model_from_file(model_file = temp_mod)
   } else {
     ## Removing tables can only be done for NONMEM datasets
   }

--- a/R/run_nlme.R
+++ b/R/run_nlme.R
@@ -113,6 +113,19 @@ run_nlme <- function(
 ) {
 
   time_start <- Sys.time()
+  
+  ## Make sure `data` is pointing to a file. This is to avoid issue with
+  ## Pharmpy trying to parse the data.frame
+  if(inherits(data, "data.frame")) {
+    datafile <- tempfile(pattern = "data_", fileext = ".csv")
+    write.csv(data, datafile, quote=F, row.names=F)
+    data <- datafile
+  } else if(inherits(data,  "character")){
+    ## no action
+  } else {
+    cli::cli_abort("`data` is of unknown type.")
+  }
+  
   ## Preserve R attributes across pharmpy calls (which create new Python objects)
   original_data <- attr(model, "original_data")
   model <- validate_model(model, data = data)

--- a/R/run_nlme.R
+++ b/R/run_nlme.R
@@ -115,15 +115,17 @@ run_nlme <- function(
   time_start <- Sys.time()
   
   ## Make sure `data` is pointing to a file. This is to avoid issue with
-  ## Pharmpy trying to parse the data.frame
-  if(inherits(data, "data.frame")) {
-    datafile <- tempfile(pattern = "data_", fileext = ".csv")
-    write.csv(data, datafile, quote=F, row.names=F)
-    data <- datafile
-  } else if(inherits(data,  "character")){
-    ## no action
-  } else {
-    cli::cli_abort("`data` is of unknown type.")
+  ## Pharmpy trying to parse the data.frame. `data` may also be NULL, in
+  ## which case `prepare_run_folder()` falls back to `model$dataset` or the
+  ## $DATA section of the model code.
+  if(!is.null(data)) {
+    if(inherits(data, "data.frame")) {
+      datafile <- tempfile(pattern = "data_", fileext = ".csv")
+      write.csv(data, datafile, quote = FALSE, row.names = FALSE)
+      data <- datafile
+    } else if(!inherits(data, "character")) {
+      cli::cli_abort("`data` is of unknown type.")
+    }
   }
   
   ## Preserve R attributes across pharmpy calls (which create new Python objects)

--- a/R/run_sim.R
+++ b/R/run_sim.R
@@ -43,6 +43,7 @@ run_sim <- function(
     seed = 12345,
     verbose = TRUE
 ) {
+  
   ## parse arguments
   if(is.null(fit) && is.null(model)) {
     cli::cli_abort("For simulations we need either a `fit` object, or a `model` file (with updated estimates)")

--- a/R/validate_model.R
+++ b/R/validate_model.R
@@ -16,7 +16,7 @@ validate_model <- function(
     if(file.exists(model)) { ## specified as file?
       model <- create_model_from_file(model)
     } else { ## specified as code?
-      tmpfile <- tempfile(pattern = "mod_")
+      tmpfile <- tempfile(pattern = "mod_", fileext = ".mod")
       on.exit(unlink(tmpfile), add = TRUE)
       writeLines(paste0(model, collapse = "\n"), tmpfile)
       model <- create_model_from_file(tmpfile, data = data)


### PR DESCRIPTION
## Summary
essentially run_nlme() was too fickle when we pass in a data.frame as data argument. That trips up Pharmpy, perhaps some issue with R <-> Python data type differences. I’ve now added code so that the first thing that happens in run_nlme() is to save the dataset to file, and then data is just passed along as the file name. This means there is zero parsing of data on the R side, and everything happens on the Python side. 

## Test plan
- [ ] `devtools::test()` passes
- [ ] `run_nlme()` works when `data` is a `data.frame`
- [ ] `run_nlme()` works when `data` is a CSV file path (existing behavior)
- [ ] `run_nlme()` aborts with a clear error when `data` is some other type
- [ ] `validate_model()` produces a tempfile with `.mod` extension when called with model code

🤖 Generated with [Claude Code](https://claude.com/claude-code)