### PR TITLE
fix dataset in model not being used in run_nlme

### DIFF
--- a/R/run_nlme.R
+++ b/R/run_nlme.R
@@ -126,6 +126,10 @@ run_nlme <- function(
     } else if(!inherits(data, "character")) {
       cli::cli_abort("`data` is of unknown type.")
     }
+  } else if (!is.null(model$dataset)) {
+    data <- model$dataset
+    datafile <- tempfile(pattern = "data_", fileext = ".csv")
+    write.csv(data, datafile, quote = FALSE, row.names = FALSE)
   }
   
   ## Preserve R attributes across pharmpy calls (which create new Python objects)


### PR DESCRIPTION
This bug showed up because a model created using create_model() gave an error saying that ENC_TIME was not in the dataset. This happened because the dataset was not saved to file to be used in the actual fit.