### PR TITLE
ci: pin stringfish/pharmr to resolve upstream API drift

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -55,7 +55,7 @@ jobs:
           pak-version: devel
           extra-packages: |
             any::rcmdcheck
-            traversc/stringfish@964e514
+            traversc/stringfish@36c0ed0
             qsbase/qs
             cran/lotri
             cran/rxode2

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -55,7 +55,7 @@ jobs:
           pak-version: devel
           extra-packages: |
             any::rcmdcheck
-            qsbase/stringfish
+            qsbase/stringfish@964e514
             qsbase/qs
             cran/lotri
             cran/rxode2

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -55,6 +55,8 @@ jobs:
           pak-version: devel
           extra-packages: |
             any::rcmdcheck
+            qsbase/stringfish
+            qsbase/qs
             cran/lotri
             cran/rxode2
             cran/nlmixr2est

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -55,7 +55,6 @@ jobs:
           pak-version: devel
           extra-packages: |
             any::rcmdcheck
-            qsbase/qs
             cran/lotri
             cran/rxode2
             cran/nlmixr2est

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -62,7 +62,7 @@ jobs:
             cran/nlmixr2est
             cran/nlmixr2extra
             cran/nlmixr2plot
-            pharmpy/pharmr
+            pharmpy/pharmr@v2.0.0
             InsightRX/irxutils
             InsightRX/PKPDsim
           needs: check

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -55,7 +55,7 @@ jobs:
           pak-version: devel
           extra-packages: |
             any::rcmdcheck
-            qsbase/stringfish@964e514
+            traversc/stringfish@964e514
             qsbase/qs
             cran/lotri
             cran/rxode2


### PR DESCRIPTION
## Summary
Three upstream regressions had stacked up since main last passed CI on 2026-04-30:

1. **`qs` 0.27.3** (GitHub HEAD) calls `sfstring::check_if_native_is_ascii`, but the `stringfish` 0.19.0 release commit (`964e514`) removed that method while keeping the version string at 0.19.0. RSPM's binary therefore satisfies `qs`'s `stringfish (>= 0.15.1)` constraint but lacks the symbol → compile error. Pin to `traversc/stringfish@36c0ed0` (the parent of 0.19.0 — last commit where the method still exists).
2. **`qs` cannot be removed** from `extra-packages`: it is CRAN-archived and required by `nlmixr2est`, so pak can't resolve it without the GitHub override.
3. **`pharmpy` 2.1.x** changed an API to require `pathlib.Path` where it used to accept `str`, breaking `clean_modelfit_data` in tests. Pin `pharmpy/pharmr@v2.0.0`; `install_pharmpy()` then installs pharmpy-core 2.0.0 via its `version="same"` default.

## Test plan
- [x] R-CMD-check passes on ubuntu-latest (R 4.5)
- [x] pkgdown builds