### PR TITLE
fix: attach dataset before adding covariate effects

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pharmr.extra
 Title: Extension of pharmr (Pharmpy) functionality
-Version: 0.0.0.9059
+Version: 0.0.0.9060
 Authors@R: c(
     person("Ron", "Keizer", email = "ron@insight-rx.com", role = c("cre", "aut")),
     person("Michael", "McCarthy", email = "michael.mccarthy@insight-rx.com", role = "ctb"),

--- a/R/add_covariates_to_model.R
+++ b/R/add_covariates_to_model.R
@@ -12,6 +12,20 @@ add_covariates_to_model <- function(
   data = NULL
 ) {
   dataset <- load_data_wrapper(data)
+  ## pharmpy's add_covariate_effect() reads `model.dataset` to compute the
+  ## covariate centering value (mean/median). When called from create_model()
+  ## the dataset has not yet been attached, so attach it here before adding
+  ## any covariate effects, then unload again so that create_model()'s later
+  ## set_dataset() + clean_modelfit_data() flow sees the same fresh state it
+  ## would otherwise see (avoids leaving a half-cleaned datainfo behind that
+  ## breaks the subsequent set_dataset() on datasets with non-numeric columns).
+  attached_temporarily <- FALSE
+  if(is.null(model$dataset) && !is.null(dataset)) {
+    model <- model |>
+      pharmr::unload_dataset() |>
+      pharmr::set_dataset(path_or_df = dataset, datatype = "nonmem")
+    attached_temporarily <- TRUE
+  }
   allowed_effects <- c("lin", "pow", "exp", "piece_lin", "cat", "cat2")
   for(par in names(covariates)) {
     for(covt in names(covariates[[par]])) {
@@ -31,6 +45,9 @@ add_covariates_to_model <- function(
         }
       }
     }
+  }
+  if(attached_temporarily) {
+    model <- pharmr::unload_dataset(model)
   }
   model
 }

--- a/tests/testthat/test-add_covariates_to_model.R
+++ b/tests/testthat/test-add_covariates_to_model.R
@@ -211,3 +211,62 @@ test_that("data as CSV filename: missing covariate warns and is skipped", {
   expect_s3_class(out, "pharmpy.model.external.nonmem.model.Model")
   expect_false(grepl("WT", out$statements$before_odes$full_expression("CL")))
 })
+
+
+## Regression test: pharmpy's add_covariate_effect() needs model.dataset to
+## compute the covariate centering value. Previously, calling create_model()
+## with both `data` and `covariates` failed with
+## "AttributeError: 'NoneType' object has no attribute 'groupby'" because the
+## dataset was attached only after add_covariates_to_model() ran.
+test_that("create_model() with `covariates` works (model dataset not yet attached)", {
+  local_pharmr.extra_options()
+  dat <- data.frame(
+    ID = rep(1:3, each = 4),
+    TIME = rep(c(0, 1, 2, 4), 3),
+    DV = c(0, 10, 8, 5, 0, 12, 9, 6, 0, 9, 7, 4),
+    AMT = rep(c(100, 0, 0, 0), 3),
+    CMT = 1,
+    EVID = rep(c(1, 0, 0, 0), 3),
+    MDV = rep(c(1, 0, 0, 0), 3),
+    WT = rep(c(70, 80, 65), each = 4),
+    CRCL = rep(c(80, 100, 90), each = 4)
+  )
+  mod <- create_model(
+    route = "oral",
+    data = dat,
+    covariates = list(CL = list(WT = "pow", CRCL = "lin"), V = list(WT = "pow")),
+    verbose = FALSE
+  )
+  expect_s3_class(mod, "pharmpy.model.external.nonmem.model.Model")
+  expect_true(grepl("WT", mod$statements$before_odes$full_expression("CL")))
+  expect_true(grepl("CRCL", mod$statements$before_odes$full_expression("CL")))
+  expect_true(grepl("WT", mod$statements$before_odes$full_expression("V")))
+})
+
+
+## Regression test: when create_model() is called with a dataset containing
+## non-numeric columns (e.g. a character GROUP column), the temporary dataset
+## attached inside add_covariates_to_model() must not leave datainfo state that
+## breaks the subsequent set_dataset() + clean_modelfit_data() flow.
+test_that("create_model() with `covariates` works when data has character cols", {
+  local_pharmr.extra_options()
+  dat <- data.frame(
+    ID = rep(1:3, each = 4),
+    TIME = rep(c(0, 1, 2, 4), 3),
+    DV = c(0, 10, 8, 5, 0, 12, 9, 6, 0, 9, 7, 4),
+    AMT = rep(c(100, 0, 0, 0), 3),
+    CMT = 1,
+    EVID = rep(c(1, 0, 0, 0), 3),
+    MDV = rep(c(1, 0, 0, 0), 3),
+    WT = rep(c(70, 80, 65), each = 4),
+    GROUP = rep(c("DrugA", "DrugB", "DrugA"), each = 4)
+  )
+  mod <- create_model(
+    route = "oral",
+    data = dat,
+    covariates = list(CL = list(WT = "pow")),
+    verbose = FALSE
+  )
+  expect_s3_class(mod, "pharmpy.model.external.nonmem.model.Model")
+  expect_true(grepl("WT", mod$statements$before_odes$full_expression("CL")))
+})


### PR DESCRIPTION
## Summary

- `create_model(data = ..., covariates = ...)` failed with `AttributeError: 'NoneType' object has no attribute 'groupby'` because pharmpy's `add_covariate_effect()` reads `model.dataset` to compute covariate centering values, but `add_covariates_to_model()` ran before the dataset was attached to the model.
- Fix: `add_covariates_to_model()` now attaches the dataset on the fly if it isn't already attached, then unloads it again so `create_model()`'s subsequent `set_dataset()` + `clean_modelfit_data()` flow is unaffected.
- Adds two regression tests for the integrated `create_model(data=..., covariates=...)` path that no existing test exercised (existing tests only covered the standalone two-step `create_model()` + `add_covariates_to_model()` flow).

## Root cause

In `R/create_model.R`, `add_covariates_to_model()` runs at line ~277 (before any dataset attachment), but the dataset is attached at line ~451. A leftover comment at the dataset-attachment block (`## Add dataset (needed if we want to add covariates to the model)`) suggests the placement was always intended to be earlier.

## Why not simply move the dataset-attach block earlier in create_model?

Tried that first — it broke several other tests:
- LTBS test: `clean_modelfit_data()` calls `set_dv("LNDV")` which now runs before `add_default_output_tables()` adds `$TABLE DV`, causing "DV is not a valid variable".
- TMDD tests: `set_tmdd()` queries the dataset for `DVID` column; with no dataset attached it worked symbolically, but with the (test) dataset attached it raised `UndefinedVariableError: name 'DVID' is not defined`.

The localized fix in `add_covariates_to_model()` avoids these side-effects.

## Test plan

- [x] New regression test for `create_model(data=..., covariates=...)` with multiple covariates on multiple parameters
- [x] New regression test for the case where the dataset contains character columns (e.g. `GROUP = "DrugA"`), which exposed a follow-up `set_dataset()` failure when the temporary attachment leaked datainfo
- [x] All existing `add_covariates_to_model` tests pass
- [x] All existing `create_model` tests pass (2 pre-existing `IPREDADJ` failures are unrelated to this change — verified by running tests on `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)