### PR TITLE
harden run_sim against pharmpy issues

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pharmr.extra
 Title: Extension of pharmr (Pharmpy) functionality
-Version: 0.0.0.9060
+Version: 0.0.0.9061
 Authors@R: c(
     person("Ron", "Keizer", email = "ron@insight-rx.com", role = c("cre", "aut")),
     person("Michael", "McCarthy", email = "michael.mccarthy@insight-rx.com", role = "ctb"),

--- a/R/add_table_to_model.R
+++ b/R/add_table_to_model.R
@@ -15,8 +15,8 @@ add_table_to_model <- function(
     model,
     variables,
     firstonly = FALSE,
-    reload_dataset = TRUE,
-    file
+    file,
+    reload_dataset = TRUE
 ) {
   check_nm_table_variables(model, variables)
   tool <- get_tool_from_model(model)

--- a/R/add_table_to_model.R
+++ b/R/add_table_to_model.R
@@ -4,7 +4,10 @@
 #' @param variables character vector with variable names
 #' @param firstonly add `FIRSTONLY` parameter to $TABLE record
 #' @param file path to file, e.g. `sdtab`
-#'
+#' @param reload_dataset should dataset be reloaded into the Pharmpy model object
+#' after updating the model. Default is TRUE, to ensure a proper Pharmpy model object,
+#' but can result in issues.
+#' 
 #' @returns TODO
 #'
 #' @export
@@ -12,6 +15,7 @@ add_table_to_model <- function(
     model,
     variables,
     firstonly = FALSE,
+    reload_dataset = TRUE,
     file
 ) {
   check_nm_table_variables(model, variables)
@@ -38,7 +42,7 @@ add_table_to_model <- function(
     model <- pharmr::read_model_from_string(
       code = paste0(model$code, table_code)
     )
-    if(!is.null(data)) {
+    if(reload_dataset && !is.null(data)) {
       model <- pharmr::set_dataset(model, data)
     }
   } else {

--- a/R/remove_tables_from_model.R
+++ b/R/remove_tables_from_model.R
@@ -3,13 +3,17 @@
 #' @param model pharmpy model object
 #' @param file remove only a specific table defined as FILE=<file>. `file` can
 #' also specify only the start of a filename, e.g. `patab`
+#' @param reload_dataset should dataset be reloaded into the Pharmpy model object
+#' after updating the model. Default is TRUE, to ensure a proper Pharmpy model object,
+#' but can result in issues.
 #'
 #' @returns TODO
 #' 
 #' @export
 remove_tables_from_model <- function(
   model,
-  file = NULL
+  file = NULL,
+  reload_dataset = TRUE
 ) {
   tool <- get_tool_from_model(model)
   if(tool == "nonmem") {
@@ -28,7 +32,7 @@ remove_tables_from_model <- function(
     temp_mod <- tempfile(pattern = "tmp_mod_", fileext = '.mod')
     writeLines(code_without_tables, temp_mod)
     model <- create_model_from_file(model_file = temp_mod)
-    if(!is.null(original_dataset)) {
+    if(reload_dataset && !is.null(original_dataset)) {
       ## `datatype = "nonmem"` keeps datainfo column types (id, dv, etc.)
       ## inferred from $INPUT — without it they get reset to "unknown".
       ## Write the dataset to a temp CSV so pharmr::set_dataset() takes the

--- a/R/run_sim.R
+++ b/R/run_sim.R
@@ -155,8 +155,8 @@ run_sim <- function(
       }
       table_variables <- unique(c(checked_variables, parameter_names))
       sim_model <- sim_model |>
-        remove_tables_from_model() |>
-        add_table_to_model(table_variables, file = output_file)
+        remove_tables_from_model(reload_dataset = FALSE) |>
+        add_table_to_model(table_variables, file = output_file, reload_dataset = FALSE)
     } else {
       if(verbose) cli::cli_alert_info("Using existing table record(s)")
     }

--- a/man/add_table_to_model.Rd
+++ b/man/add_table_to_model.Rd
@@ -4,7 +4,13 @@
 \alias{add_table_to_model}
 \title{Add new $TABLE record to output variables}
 \usage{
-add_table_to_model(model, variables, firstonly = FALSE, file)
+add_table_to_model(
+  model,
+  variables,
+  firstonly = FALSE,
+  reload_dataset = TRUE,
+  file
+)
 }
 \arguments{
 \item{model}{pharmpy model object}
@@ -12,6 +18,10 @@ add_table_to_model(model, variables, firstonly = FALSE, file)
 \item{variables}{character vector with variable names}
 
 \item{firstonly}{add \code{FIRSTONLY} parameter to $TABLE record}
+
+\item{reload_dataset}{should dataset be reloaded into the Pharmpy model object
+after updating the model. Default is TRUE, to ensure a proper Pharmpy model object,
+but can result in issues.}
 
 \item{file}{path to file, e.g. \code{sdtab}}
 }

--- a/man/remove_tables_from_model.Rd
+++ b/man/remove_tables_from_model.Rd
@@ -4,13 +4,17 @@
 \alias{remove_tables_from_model}
 \title{Remove all $TABLE records from a model}
 \usage{
-remove_tables_from_model(model, file = NULL)
+remove_tables_from_model(model, file = NULL, reload_dataset = TRUE)
 }
 \arguments{
 \item{model}{pharmpy model object}
 
 \item{file}{remove only a specific table defined as FILE=\if{html}{\out{<file>}}. \code{file} can
 also specify only the start of a filename, e.g. \code{patab}}
+
+\item{reload_dataset}{should dataset be reloaded into the Pharmpy model object
+after updating the model. Default is TRUE, to ensure a proper Pharmpy model object,
+but can result in issues.}
 }
 \value{
 TODO

--- a/tests/testthat/test-add_table_to_model.R
+++ b/tests/testthat/test-add_table_to_model.R
@@ -83,6 +83,39 @@ test_that("handles empty variables", {
   expect_equal(result$code, mod$code)
 })
 
+test_that("reload_dataset controls whether dataset is reattached", {
+  dat <- data.frame(
+    ID = 1,
+    TIME = c(0, 1, 2),
+    DV = c(0, 10, 5),
+    AMT = c(100, 0, 0),
+    CMT = 1,
+    EVID = c(1, 0, 0),
+    MDV = c(1, 0, 0)
+  )
+  mod <- create_model(route = "iv", data = dat, tables = NULL, verbose = FALSE)
+  expect_false(is.null(mod$dataset))
+
+  # Default (reload_dataset = TRUE): dataset is reattached
+  out_true <- add_table_to_model(
+    model = mod,
+    variables = c("ID", "CL", "V"),
+    file = "patab"
+  )
+  expect_equal(out_true$dataset, mod$dataset, ignore_attr = TRUE)
+  expect_true(grepl("FILE=patab", out_true$code))
+
+  # reload_dataset = FALSE: skip the set_dataset() call; table still added
+  out_false <- add_table_to_model(
+    model = mod,
+    variables = c("ID", "CL", "V"),
+    file = "patab",
+    reload_dataset = FALSE
+  )
+  expect_null(out_false$dataset)
+  expect_true(grepl("FILE=patab", out_false$code))
+})
+
 test_that("errors on invalid variables", {
   dat <- data.frame(
     ID = 1,

--- a/tests/testthat/test-remove_tables_from_model.R
+++ b/tests/testthat/test-remove_tables_from_model.R
@@ -255,3 +255,28 @@ test_that("preserves dataset when removing tables", {
   out <- remove_tables_from_model(model = mod, file = NULL)
   expect_equal(out$dataset, mod$dataset, ignore_attr = TRUE)
 })
+
+test_that("reload_dataset = FALSE skips reattaching dataset", {
+  local_pharmr.extra_options()
+  dat <- data.frame(
+    ID = c(1, 1, 1, 2, 2, 2),
+    TIME = c(0, 1, 2, 0, 1, 2),
+    DV = c(0, 10, 5, 0, 12, 6),
+    AMT = c(100, 0, 0, 100, 0, 0),
+    CMT = 1,
+    EVID = c(1, 0, 0, 1, 0, 0),
+    MDV = c(1, 0, 0, 1, 0, 0)
+  )
+  mod <- create_model(
+    route = "iv", data = dat, tables = c("fit", "parameters"), verbose = FALSE
+  )
+  expect_false(is.null(mod$dataset))
+
+  out <- remove_tables_from_model(model = mod, file = NULL, reload_dataset = FALSE)
+
+  # Tables are still removed from the code...
+  expect_length(get_tables_in_model_code(out$code), 0)
+  expect_false(grepl("\\$TABLE", out$code))
+  # ...but the dataset is not reattached.
+  expect_null(out$dataset)
+})


### PR DESCRIPTION
run_sim() was still running into Pharmpy issues with reloading datasets that contain `.` or other characters. It now avoids reloading the dataset when updating $TABLE.