### PR TITLE
feat(nlmixr): support raw nlmixr2 fits in update_parameters()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pharmr.extra
 Title: Extension of pharmr (Pharmpy) functionality
-Version: 0.0.0.9069
+Version: 0.0.0.9070
 Authors@R: c(
     person("Ron", "Keizer", email = "ron@insight-rx.com", role = c("cre", "aut")),
     person("Michael", "McCarthy", email = "michael.mccarthy@insight-rx.com", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # pharmr.extra (development version)
 
+* `update_parameters()` now also accepts a raw `nlmixr2FitCore` / `nlmixr2FitData`
+  object — useful when fitting outside `run_nlme()`. Both diagonal and
+  off-diagonal omega elements are extracted and named per pharmpy's
+  `IIV_X` / `IIV_X_IIV_Y` convention, so block-omega covariances are now
+  updated alongside variance terms (previously dropped).
 * `run_nlme()`, `run_sim()`, and `create_vpc_data()` now dispatch on the model
   engine. Pharmpy nlmixr-format models are routed through nlmixr2 / rxode2
   directly (no pharmpy `pyreadr` dependency). NONMEM models still use the

--- a/R/run_nlme_nlmixr.R
+++ b/R/run_nlme_nlmixr.R
@@ -201,30 +201,13 @@ extract_nlmixr_function <- function(code) {
 #' @noRd
 as_pharmpy_shaped_fit <- function(raw_fit, model, input_data = NULL) {
   pf <- raw_fit$parFixedDf
-  ## Population fixed-effect names + estimates
-  est_fixed <- stats::setNames(pf$Estimate, rownames(pf))
   se_fixed  <- stats::setNames(pf$SE, rownames(pf))
 
-  ## Random-effect (omega) variances on the diagonal — pharmpy names these
-  ## IIV_<param>, while nlmixr2 names the omega rows ETA_<param>. Strip the
-  ## ETA_ prefix and re-prefix with IIV_ so update_parameters() can match.
-  om <- raw_fit$omega
-  iiv_estimates <- if(!is.null(om) && nrow(om) > 0) {
-    iiv_names <- paste0("IIV_", sub("^ETA_", "", rownames(om)))
-    stats::setNames(diag(as.matrix(om)), iiv_names)
-  } else {
-    numeric(0)
-  }
-
-  parameter_estimates <- c(est_fixed, iiv_estimates)
-
-  ## Filter to names the pharmpy model recognises so set_initial_estimates()
-  ## doesn't reject unknown keys (e.g. residual error parameters whose
-  ## scale conventions differ between nlmixr2 and pharmpy).
-  known <- tryCatch(model$parameters$names, error = function(e) NULL)
-  if(!is.null(known)) {
-    parameter_estimates <- parameter_estimates[names(parameter_estimates) %in% known]
-  }
+  ## Use the shared extraction helper so block-omega off-diagonals
+  ## (pharmpy parameter name IIV_X_IIV_Y) are also picked up. The helper
+  ## handles ETA_X NaN-row filtering and pharmpy-name mapping for us.
+  parameter_estimates <- nlmixr_parameter_estimates(raw_fit, model = model)
+  if(is.null(parameter_estimates)) parameter_estimates <- numeric(0)
 
   ## Build standard_errors and relative_standard_errors aligned with
   ## parameter_estimates by name. nlmixr2 reports SEs only for fixed effects;

--- a/R/update_parameters.R
+++ b/R/update_parameters.R
@@ -2,11 +2,23 @@
 #'
 #' For example for using model in simulations.
 #'
+#' Supports both NONMEM-backend and nlmixr-backend pharmpy models. The `fit`
+#' argument may be:
+#' - a pharmpy `ModelfitResults` object (NONMEM path)
+#' - the pharmpy-shaped wrapper returned by [run_nlme()] on an nlmixr model
+#' - a raw `nlmixr2FitCore` object (output of [nlmixr2::nlmixr2()] called
+#'   directly, without going through [run_nlme()])
+#'
+#' For nlmixr2 fits, both diagonal and off-diagonal omega elements are
+#' extracted so that block-omega parameters (named `IIV_X_IIV_Y` in pharmpy)
+#' are updated alongside the variance terms.
+#'
 #' @inheritParams attach_fit_info
 #' @param fix fix the estimates?
-#' 
-#' @returns TODO
-#' 
+#'
+#' @returns the input pharmpy model with parameter estimates updated, or
+#'   `invisible(NULL)` if no estimates were available
+#'
 #' @export
 update_parameters <- function(
     model,
@@ -14,10 +26,7 @@ update_parameters <- function(
     fix = FALSE,
     verbose = FALSE
 ) {
-  # TODO: what's the purpose of final_model? We create the object but don't do
-  # anything with it.
-  final_model <- attr(fit, "model") 
-  params <- fit$parameter_estimates
+  params <- extract_parameter_estimates(fit, model)
   if(is.null(params)) {
     cli::cli_warn("No parameter estimates found in fit object; cannot update model.")
     return(invisible())
@@ -42,4 +51,90 @@ update_parameters <- function(
     )
   }
   model
+}
+
+#' Pull a named numeric vector of parameter estimates from a fit object
+#'
+#' Dispatches on the fit's class: pharmpy fits already expose
+#' `parameter_estimates`, raw nlmixr2 fits do not and need their fixed-effect
+#' and omega slots stitched together. Returns NULL when nothing usable can be
+#' read out (so [update_parameters()] can warn and return).
+#'
+#' @noRd
+extract_parameter_estimates <- function(fit, model = NULL) {
+  if(is_raw_nlmixr2_fit(fit)) {
+    return(nlmixr_parameter_estimates(fit, model = model))
+  }
+  ## pharmpy ModelfitResults and the pharmpy-shaped wrapper both expose this
+  fit$parameter_estimates
+}
+
+#' Detect a raw `nlmixr2::nlmixr2()` fit object
+#'
+#' These inherit from `nlmixr2FitCore` / `nlmixr2FitData`. Distinct from the
+#' pharmpy-shaped wrapper, which has class `nlmixr2_modelfit_results`.
+#'
+#' @noRd
+is_raw_nlmixr2_fit <- function(fit) {
+  inherits(fit, c("nlmixr2FitCore", "nlmixr2FitData"))
+}
+
+#' Convert a raw nlmixr2 fit into a named vector of pharmpy-style parameter estimates
+#'
+#' Mirrors pharmpy's `IIV_X` / `IIV_X_IIV_Y` naming so that
+#' `pharmr::set_initial_estimates()` and `pharmr::fix_parameters_to()` can be
+#' applied directly. When `model` is supplied, the result is filtered to
+#' parameters the model recognises, and off-diagonals are emitted in whichever
+#' of `IIV_X_IIV_Y` / `IIV_Y_IIV_X` the model uses.
+#'
+#' @noRd
+nlmixr_parameter_estimates <- function(raw_fit, model = NULL) {
+  pf <- raw_fit$parFixedDf
+  est_fixed <- if(!is.null(pf) && nrow(pf) > 0) {
+    v <- stats::setNames(pf$Estimate, rownames(pf))
+    v[!is.na(v)]  # parFixedDf has NaN rows for ETA_X; drop them
+  } else {
+    numeric(0)
+  }
+
+  om <- raw_fit$omega
+  iiv_estimates <- numeric(0)
+  if(!is.null(om) && nrow(om) > 0) {
+    om <- as.matrix(om)
+    diag_labels <- sub("^ETA_", "", rownames(om))
+    diag_estimates <- stats::setNames(diag(om), paste0("IIV_", diag_labels))
+
+    offdiag_estimates <- numeric(0)
+    n <- nrow(om)
+    if(n > 1) {
+      known <- tryCatch(model$parameters$names, error = function(e) NULL)
+      for(i in seq_len(n - 1)) {
+        for(j in seq.int(i + 1, n)) {
+          v <- om[i, j]
+          if(is.na(v)) next
+          nm <- paste0("IIV_", diag_labels[i], "_IIV_", diag_labels[j])
+          alt <- paste0("IIV_", diag_labels[j], "_IIV_", diag_labels[i])
+          ## When the model uses a different ordering for the block parameter
+          ## name, prefer that. When the model has no block parameter at all,
+          ## the entry will be filtered out below — there's no harm emitting it.
+          if(!is.null(known) && !(nm %in% known) && (alt %in% known)) nm <- alt
+          offdiag_estimates[nm] <- v
+        }
+      }
+    }
+    iiv_estimates <- c(diag_estimates, offdiag_estimates)
+  }
+
+  parameter_estimates <- c(est_fixed, iiv_estimates)
+
+  ## Filter to names the pharmpy model recognises so set_initial_estimates()
+  ## doesn't reject unknown keys (e.g. residual-error parameters whose scale
+  ## conventions differ between nlmixr2 and pharmpy).
+  known <- tryCatch(model$parameters$names, error = function(e) NULL)
+  if(!is.null(known)) {
+    parameter_estimates <- parameter_estimates[names(parameter_estimates) %in% known]
+  }
+
+  if(length(parameter_estimates) == 0) return(NULL)
+  parameter_estimates
 }

--- a/man/update_parameters.Rd
+++ b/man/update_parameters.Rd
@@ -17,8 +17,23 @@ to NONMEM model file.}
 \item{verbose}{verbose output?}
 }
 \value{
-TODO
+the input pharmpy model with parameter estimates updated, or
+\code{invisible(NULL)} if no estimates were available
 }
 \description{
 For example for using model in simulations.
+}
+\details{
+Supports both NONMEM-backend and nlmixr-backend pharmpy models. The \code{fit}
+argument may be:
+\itemize{
+\item a pharmpy \code{ModelfitResults} object (NONMEM path)
+\item the pharmpy-shaped wrapper returned by \code{\link[=run_nlme]{run_nlme()}} on an nlmixr model
+\item a raw \code{nlmixr2FitCore} object (output of \code{\link[nlmixr2:nlmixr2]{nlmixr2::nlmixr2()}} called
+directly, without going through \code{\link[=run_nlme]{run_nlme()}})
+}
+
+For nlmixr2 fits, both diagonal and off-diagonal omega elements are
+extracted so that block-omega parameters (named \code{IIV_X_IIV_Y} in pharmpy)
+are updated alongside the variance terms.
 }

--- a/tests/testthat/test-update_parameters.R
+++ b/tests/testthat/test-update_parameters.R
@@ -15,7 +15,86 @@ test_that("updates parameters from fit object with fix = TRUE", {
   fit <- pharmr::load_example_modelfit_results("pheno")
   out <- update_parameters(mod, fit, fix = TRUE, verbose = FALSE)
   params_df <- out$parameters$to_dataframe()
-  
+
   expect_true(all(params_df$fix))
   expect_s3_class(out, "pharmpy.model.external.nonmem.model.Model")
+})
+
+test_that("update_parameters() handles a raw nlmixr2 fit object", {
+  local_pharmr.extra_options()
+  mod <- pharmr::create_basic_pk_model(administration = "oral")
+  mod <- pharmr::convert_model(mod, "nlmixr")
+
+  ## A minimal stand-in for an nlmixr2 fit: parFixedDf for THETAs + residual
+  ## error, omega for ETAs (block CL/VC + diagonal MAT). We only need the
+  ## slots update_parameters() reads, so we tag the object with the right
+  ## class and skip running an actual fit (nlmixr2 may not be installed).
+  fake_raw_fit <- structure(
+    list(
+      parFixedDf = data.frame(
+        Estimate = c(2.5, 22.0, 0.4, 0.15, NA, NA, NA),
+        row.names = c("POP_CL", "POP_VC", "POP_MAT", "sigma",
+                      "ETA_CL", "ETA_VC", "ETA_MAT")
+      ),
+      omega = matrix(
+        c(0.05, 0.02, 0,
+          0.02, 0.06, 0,
+          0,    0,    0.04),
+        nrow = 3,
+        dimnames = list(c("ETA_CL", "ETA_VC", "ETA_MAT"),
+                        c("ETA_CL", "ETA_VC", "ETA_MAT"))
+      )
+    ),
+    class = c("nlmixr2FitData", "nlmixr2FitCore", "list")
+  )
+
+  out <- update_parameters(mod, fake_raw_fit, fix = FALSE)
+  params <- out$parameters$to_dataframe()
+
+  ## Population parameters and the residual error were applied
+  expect_equal(params["POP_CL", "value"], 2.5)
+  expect_equal(params["POP_VC", "value"], 22.0)
+  expect_equal(params["POP_MAT", "value"], 0.4)
+  expect_equal(params["sigma", "value"], 0.15)
+
+  ## Both diagonal and off-diagonal omega entries were applied — the
+  ## off-diagonal name uses pharmpy's `IIV_X_IIV_Y` convention.
+  expect_equal(params["IIV_CL", "value"], 0.05)
+  expect_equal(params["IIV_VC", "value"], 0.06)
+  expect_equal(params["IIV_MAT", "value"], 0.04)
+  expect_equal(params["IIV_CL_IIV_VC", "value"], 0.02)
+})
+
+test_that("update_parameters() with fix=TRUE on a raw nlmixr2 fit fixes block elements", {
+  local_pharmr.extra_options()
+  mod <- pharmr::create_basic_pk_model(administration = "oral")
+  mod <- pharmr::convert_model(mod, "nlmixr")
+
+  fake_raw_fit <- structure(
+    list(
+      parFixedDf = data.frame(
+        Estimate = c(2.5, 22.0, 0.4, 0.15, NA, NA, NA),
+        row.names = c("POP_CL", "POP_VC", "POP_MAT", "sigma",
+                      "ETA_CL", "ETA_VC", "ETA_MAT")
+      ),
+      omega = matrix(
+        c(0.05, 0.02, 0,
+          0.02, 0.06, 0,
+          0,    0,    0.04),
+        nrow = 3,
+        dimnames = list(c("ETA_CL", "ETA_VC", "ETA_MAT"),
+                        c("ETA_CL", "ETA_VC", "ETA_MAT"))
+      )
+    ),
+    class = c("nlmixr2FitData", "nlmixr2FitCore", "list")
+  )
+
+  out <- update_parameters(mod, fake_raw_fit, fix = TRUE)
+  params <- out$parameters$to_dataframe()
+
+  ## The block off-diagonal must also be fixed — not just the diagonal terms.
+  expect_true(params["IIV_CL_IIV_VC", "fix"])
+  expect_true(params["IIV_CL", "fix"])
+  expect_true(params["IIV_VC", "fix"])
+  expect_true(params["sigma", "fix"])
 })


### PR DESCRIPTION
## Summary

- `update_parameters()` now accepts a raw `nlmixr2FitCore` / `nlmixr2FitData` object (output of `nlmixr2::nlmixr2()` called outside `run_nlme()`). Previously it required `fit$parameter_estimates` and silently warned "cannot update model" on raw nlmixr2 fits.
- Block-omega off-diagonals are now extracted from the omega matrix and named per pharmpy's `IIV_X_IIV_Y` convention. Previously only `diag(omega)` was taken, so pharmpy auto-rescaled the block when the old off-diagonal violated positive-definiteness.
- `run_nlme()` on an nlmixr model benefits too: `as_pharmpy_shaped_fit()` now reuses the same helper, so the saved `final.R` reflects the fitted covariance.

## Test plan

- [x] `devtools::test(filter = "update_parameters")` — 16 pass (2 new tests covering raw nlmixr2 fit with block omega for both `fix = FALSE` and `fix = TRUE`).
- [x] `devtools::test(filter = "run_nlme_nlmixr")` — 23 pass.
- [x] Full `devtools::test()` — 1634 pass. The 2 pre-existing failures in `test-create_model.R` (RUV `IPREDADJ` expression text) reproduce on the branch HEAD prior to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)