### PR TITLE
fix(initial-estimates): handle EVID=2 rows and empty dose lookups

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pharmr.extra
 Title: Extension of pharmr (Pharmpy) functionality
-Version: 0.0.0.9071
+Version: 0.0.0.9072
 Authors@R: c(
     person("Ron", "Keizer", email = "ron@insight-rx.com", role = c("cre", "aut")),
     person("Michael", "McCarthy", email = "michael.mccarthy@insight-rx.com", role = "ctb"),

--- a/R/get_initial_estimates_from_data.R
+++ b/R/get_initial_estimates_from_data.R
@@ -34,7 +34,9 @@ get_initial_estimates_from_data <- function(
         TIME = as.numeric(.data$TIME)
       ) |>
       dplyr::group_by(.data$ID) |>
-      dplyr::mutate(dosenr = cumsum(.data$EVID)) |>
+      ## Count only actual dose events. Using cumsum(EVID) inflates the
+      ## counter on EVID=2/3/4 rows and breaks the dose-to-observation join.
+      dplyr::mutate(dosenr = cumsum(.data$EVID == 1)) |>
       dplyr::ungroup()
   )
   if(ltbs) {
@@ -72,9 +74,12 @@ get_initial_estimates_from_data <- function(
     weighted.mean(x, w = w)
   }
 
-  est <- as.list(apply(tmp[,1:2], 2, function(x) {
-    signif(safe_weighted_mean(x, w = tmp$weight), 3)
-  }))
+  ## Pool V and CL across subjects by name (not position) so an out-of-order
+  ## per-subject vector can't shift columns into the wrong slot.
+  est <- list(
+    V  = signif(safe_weighted_mean(tmp$V,  w = tmp$weight), 3),
+    CL = signif(safe_weighted_mean(tmp$CL, w = tmp$weight), 3)
+  )
   if(n_cmt >= 2) {
     est$QP1 <- est$CL
     est$VP1 <- est$V * 2
@@ -108,7 +113,7 @@ get_initial_estimates_from_individual_data <- function(
   ## calls, but handle here too so the function works when called directly)
   if(!is.numeric(dat$DV))   dat$DV   <- suppressWarnings(as.numeric(dat$DV))
   if(!is.numeric(dat$TIME)) dat$TIME <- suppressWarnings(as.numeric(dat$TIME))
-  if(is.null(dat$dosenr))   dat$dosenr <- cumsum(dat$EVID)
+  if(is.null(dat$dosenr))   dat$dosenr <- cumsum(dat$EVID == 1)
 
   if(ltbs) {
     dat$DV <- ifelse(dat$EVID == 0, exp(dat$DV), dat$DV)
@@ -135,14 +140,22 @@ get_initial_estimates_from_individual_data <- function(
   obs <- dat[obs_mask, ]
   tmp <- tail(obs, 3)
   dose <- dat$AMT[dat$dosenr == dose_nr & dat$EVID == 1]
-  est <- c()
+  ## If no dose can be matched to this observation set (e.g. observations
+  ## before any dose was administered, or a malformed AMT/EVID pairing) we
+  ## cannot ballpark V or CL. Return an explicit V/CL/weight triple so the
+  ## caller never receives a partial vector — unlist() silently drops
+  ## length-0 slots, which would otherwise misalign downstream columns.
+  if (length(dose) == 0 || all(is.na(dose))) {
+    return(c(V = NA_real_, CL = NA_real_, weight = 0))
+  }
+  est <- list(V = NA_real_, CL = NA_real_, weight = 0)
   n_points <- length(unique(tmp$TIME))
   if(inherits(tmp$TIME, "numeric") && n_points > 1) { # two datapoints at least
     fit <- stats::lm(log(DV) ~ TIME, tmp)
     KEL <- -as.numeric(coef(fit)[2])
     if(is.null(KEL) || is.na(KEL)) {
-      est$V <- NA
-      est$CL <- NA
+      est$V <- NA_real_
+      est$CL <- NA_real_
     } else {
       if (KEL <= 0) { # fallback for absorption-phase or flat data
         KEL <- (log(max(obs$DV, na.rm=TRUE)) - log(min(obs$DV[obs$DV > 0], na.rm=TRUE))) / diff(range(obs$TIME))
@@ -157,8 +170,8 @@ get_initial_estimates_from_individual_data <- function(
       est$CL <- est$V / 20
       est$weight <- 0.001 # downweigh this, since very crude estimate. Only use if no subjects with >2 samples available
     } else { # for placebo patients, DV may all be zero or NA so we should not attempt to ballpark V or CL
-      est$V <- NA
-      est$CL <- NA
+      est$V <- NA_real_
+      est$CL <- NA_real_
       est$weight <- 0
     }
   }

--- a/tests/testthat/test-get_initial_estimates_from_data.R
+++ b/tests/testthat/test-get_initial_estimates_from_data.R
@@ -386,3 +386,89 @@ test_that("get_initial_estimates_from_data gives same result regardless of AMT c
   expect_equal(result_numeric$V,  result_factor$V,     tolerance = 1e-6)
   expect_equal(result_numeric$CL, result_factor$CL,    tolerance = 1e-6)
 })
+
+test_that("get_initial_estimates_from_data is robust to EVID=2 rows (other-event/reset rows)", {
+  # NONMEM datasets often contain EVID=2 rows (other-event, e.g. covariate
+  # changes). They are not dose events and must not increment the per-subject
+  # dose counter. Previously, cumsum(EVID) inflated the counter on EVID=2 rows
+  # so the observation lookup couldn't find a matching AMT, the resulting V/CL
+  # were length-0, and unlist() silently dropped them — producing a degenerate
+  # `c(weight = ...)` vector. The pooled result then carried a `weight`
+  # parameter, which downstream pharmpy rejected as `POP_weight`.
+  with_evid2 <- data.frame(
+    ID   = c(1, 1, 1, 1, 1),
+    TIME = c(0, 0.5, 1, 4, 8),
+    DV   = c(0, 0,   100, 50, 25),
+    EVID = c(1, 2,   0,   0,  0),  # EVID=2 row sits between dose and obs
+    MDV  = c(1, 1,   0,   0,  0),
+    AMT  = c(1000, 0, 0,  0,  0)
+  )
+  without_evid2 <- data.frame(
+    ID   = c(1, 1, 1, 1),
+    TIME = c(0, 1, 4, 8),
+    DV   = c(0, 100, 50, 25),
+    EVID = c(1, 0, 0, 0),
+    MDV  = c(1, 0, 0, 0),
+    AMT  = c(1000, 0, 0, 0)
+  )
+
+  result_with    <- get_initial_estimates_from_data(with_evid2,    n_cmt = 1)
+  result_without <- get_initial_estimates_from_data(without_evid2, n_cmt = 1)
+
+  expect_named(result_with, c("V", "CL"))
+  expect_false("weight" %in% names(result_with))
+  expect_equal(result_with$V,  result_without$V,  tolerance = 1e-6)
+  expect_equal(result_with$CL, result_without$CL, tolerance = 1e-6)
+})
+
+test_that("get_initial_estimates_from_individual_data returns V/CL/weight even when no dose precedes observations", {
+  # Subject has observations before any EVID=1 dose record (e.g. baseline /
+  # pre-dose samples in a screening period). With cumsum(EVID==1), those obs
+  # are bucketed under dose_nr = 0, for which no AMT row exists. The function
+  # must return a full V/CL/weight vector (with NA V/CL) rather than a
+  # partial one that unlist() would collapse to just `weight`.
+  test_data <- data.frame(
+    ID   = 1,
+    TIME = c(0, 1, 4),
+    DV   = c(5, 7, 6),
+    EVID = c(0, 0, 0),
+    MDV  = c(0, 0, 0),
+    AMT  = c(0, 0, 0)
+  )
+
+  estimates <- get_initial_estimates_from_individual_data(test_data)
+
+  expect_named(estimates, c("V", "CL", "weight"))
+  expect_true(is.na(estimates[["V"]]))
+  expect_true(is.na(estimates[["CL"]]))
+  expect_equal(estimates[["weight"]], 0)
+})
+
+test_that("get_initial_estimates_from_data never returns a 'weight' parameter, even with degenerate subjects", {
+  # Mix of a richly sampled subject and a subject whose observations sit
+  # before any dose (no AMT match). The pooled result must contain only V and
+  # CL — any spurious 'weight' entry here breaks set_initial_estimates with
+  # ValueError: Parameters not found in model: ['POP_weight'].
+  rich <- data.frame(
+    ID   = 1,
+    TIME = c(0, 1, 4, 8),
+    DV   = c(0, 100, 50, 25),
+    EVID = c(1, 0, 0, 0),
+    MDV  = c(1, 0, 0, 0),
+    AMT  = c(1000, 0, 0, 0)
+  )
+  pre_dose_only <- data.frame(
+    ID   = 2,
+    TIME = c(0, 1, 4),
+    DV   = c(5, 7, 6),
+    EVID = c(0, 0, 0),
+    MDV  = c(0, 0, 0),
+    AMT  = c(0, 0, 0)
+  )
+
+  result <- get_initial_estimates_from_data(rbind(rich, pre_dose_only), n_cmt = 1)
+
+  expect_named(result, c("V", "CL"))
+  expect_false("weight" %in% names(result))
+  expect_true(all(unlist(result) > 0))
+})


### PR DESCRIPTION
## Summary

- `get_initial_estimates_from_data` produced a malformed `inits` list on real NONMEM datasets containing EVID=2 rows (other-event / reset), causing `pharmr::set_initial_estimates` to fail with `ValueError: Parameters not found in model: ['POP_weight']`.
- Two compounding bugs: `dosenr = cumsum(EVID)` inflated the per-subject dose counter on EVID=2 rows so the AMT lookup returned `numeric(0)`, and the resulting length-0 V/CL slots were silently dropped by `unlist()` — the per-subject vector collapsed to `c(weight = n_points)`, which then ended up in column 1 of the pooled tibble.

## Changes

- `cumsum(EVID == 1)` in both call sites — only actual dose events increment the counter.
- Empty-dose guard in `get_initial_estimates_from_individual_data` returns an explicit `c(V = NA, CL = NA, weight = 0)`, so callers always receive V/CL/weight (no partial vectors that `unlist()` would silently truncate).
- Pool V and CL by column name rather than `tmp[, 1:2]` positionally — defensive belt against any future ordering bugs.

## Test plan

- [x] 3 new regression tests: EVID=2 rows produce identical estimates to the EVID=2-free dataset; individual function returns full triple when no dose precedes obs; pooled output never contains a spurious `weight` parameter.
- [x] `devtools::test(filter = "get_initial_estimates_from_data")` → 71/71 pass.
- [x] Full `devtools::test()` → only 2 failures, both pre-existing in `test-create_model.R` (RUV settings) and unrelated to this code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)