### PR TITLE
test(ruv): update combined and ltbs Y-expression assertions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pharmr.extra
 Title: Extension of pharmr (Pharmpy) functionality
-Version: 0.0.0.9072
+Version: 0.0.0.9073
 Authors@R: c(
     person("Ron", "Keizer", email = "ron@insight-rx.com", role = c("cre", "aut")),
     person("Michael", "McCarthy", email = "michael.mccarthy@insight-rx.com", role = "ctb"),

--- a/tests/testthat/test-create_model.R
+++ b/tests/testthat/test-create_model.R
@@ -469,14 +469,18 @@ test_that("RUV settings work as expected", {
   # Test combined error
   mod <- create_model(ruv = "combined")
   expect_equal(
-    "EPS_1*IPREDADJ + EPS_2 + IPRED",
+    "EPS_1*IPRED + EPS_2 + IPRED",
     as.character(mod$statements$find_assignment("Y")$expression)
   )
 
-  # Test log-transformed both sides
+  # Test log-transformed both sides. The LTBS workaround in
+  # set_residual_error() calls set_additive_error_model() before
+  # set_proportional_error_model(data_trans = "log(Y)"), so pharmpy emits a
+  # safe-divide variable named IPREDADJ1 (IPREDADJ is taken by the additive
+  # step).
   mod <- create_model(ruv = "ltbs")
   expect_equal(
-    "EPS_1 + log(IPREDADJ)",
+    "EPS_1 + log(IPREDADJ1)",
     as.character(mod$statements$find_assignment("Y")$expression)
   )
 })


### PR DESCRIPTION
## Summary
Pre-existing failures in `test_that("RUV settings work as expected", ...)`:

1. **combined**: pharmpy's combined error model now writes `Y = EPS_1*IPRED + EPS_2 + IPRED`. Previously the proportional term used `IPREDADJ` (the safe-divide alias). The model is mathematically equivalent — only the symbol referenced in the proportional term changed.
2. **ltbs**: `set_residual_error()` implements LTBS as `set_additive_error_model() |> set_proportional_error_model(data_trans = "log(Y)")`. The additive step now consumes the symbol `IPREDADJ`, so the proportional step's safe-divide variable becomes `IPREDADJ1`, and that is what appears inside `log()`.

Both are pharmpy-internal naming changes; the generated NONMEM `\$ERROR` blocks remain numerically correct. Updated the test assertions accordingly and added a short comment on the LTBS case so the `IPREDADJ1` name doesn't look surprising next time.

## Test plan
- [x] `devtools::test(filter = "create_model")` — all 314 assertions pass, only pre-existing skip remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)