### PR TITLE
feat(covsearch): auto-uppercase MFL search_space and model columns

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pharmr.extra
 Title: Extension of pharmr (Pharmpy) functionality
-Version: 0.0.0.9074
+Version: 0.0.0.9075
 Authors@R: c(
     person("Ron", "Keizer", email = "ron@insight-rx.com", role = c("cre", "aut")),
     person("Michael", "McCarthy", email = "michael.mccarthy@insight-rx.com", role = "ctb"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pharmr.extra
 Title: Extension of pharmr (Pharmpy) functionality
-Version: 0.0.0.9072
+Version: 0.0.0.9074
 Authors@R: c(
     person("Ron", "Keizer", email = "ron@insight-rx.com", role = c("cre", "aut")),
     person("Michael", "McCarthy", email = "michael.mccarthy@insight-rx.com", role = "ctb"),

--- a/R/call_pharmpy_tool.R
+++ b/R/call_pharmpy_tool.R
@@ -16,6 +16,12 @@
 #' https://pharmpy.github.io/latest/mfl.html.
 #' @param remove_tables if `TRUE` (default), removes all `$TABLE` records from the model
 #' before passing it to the Pharmpy tool.
+#' @param uppercase_mfl if `TRUE` (default), uppercases the model's `$INPUT` /
+#' datainfo / dataset column names and the `options$search_space` string before
+#' calling the Pharmpy tool. Works around Pharmpy's MFL parser, which
+#' unconditionally uppercases every identifier in a search_space and then fails
+#' the case-sensitive lookup against datainfo (see
+#' <https://github.com/pharmpy/pharmpy/issues/4576>). Set to `FALSE` to disable.
 #'
 #' @return fit object
 #'
@@ -50,7 +56,8 @@ call_pharmpy_tool <- function(
   verbose = TRUE,
   force = FALSE,
   options = list(),
-  remove_tables = TRUE
+  remove_tables = TRUE,
+  uppercase_mfl = TRUE
 ) {
 
   if(is.null(tool)) {
@@ -172,6 +179,33 @@ call_pharmpy_tool <- function(
       cli::cli_alert_info(
         "No `search_space` provided; defaulting to {.val IIV(@PK,EXP)}"
       )
+  }
+
+  ## MFL case-sensitivity workaround (pharmpy/pharmpy#4576): the MFL parser
+  ## uppercases all identifiers in `search_space`, then validates them
+  ## case-sensitively against `datainfo.names`. To make lowercase column
+  ## conventions work, warn on lowercase identifiers in the search_space and
+  ## uppercase both the search_space string and the model's columns.
+  if(uppercase_mfl) {
+    if(!is.null(options$search_space)) {
+      lowercase_ids <- detect_lowercase_identifiers(options$search_space)
+      if(length(lowercase_ids) > 0 && verbose) {
+        cli::cli_alert_warning(c(
+          "{.code search_space} contains lowercase identifier{?s}: {.val {lowercase_ids}}.",
+          i = "Pharmpy's MFL parser uppercases all identifiers (see {.url https://github.com/pharmpy/pharmpy/issues/4576}); uppercasing now."
+        ))
+      }
+      options$search_space <- toupper(options$search_space)
+    }
+    renamed <- uppercase_model_columns(model)
+    if(length(renamed$renamed) > 0) {
+      if(verbose) {
+        cli::cli_alert_info(c(
+          "Uppercased {length(renamed$renamed)} model column{?s} to match MFL parser: {.val {paste0(names(renamed$renamed), ' -> ', unname(renamed$renamed))}}"
+        ))
+      }
+      model <- renamed$model
+    }
   }
 
   ## prepare arguments for call

--- a/R/call_pharmpy_tool.R
+++ b/R/call_pharmpy_tool.R
@@ -185,18 +185,19 @@ call_pharmpy_tool <- function(
   ## uppercases all identifiers in `search_space`, then validates them
   ## case-sensitively against `datainfo.names`. To make lowercase column
   ## conventions work, warn on lowercase identifiers in the search_space and
-  ## uppercase both the search_space string and the model's columns.
-  if(uppercase_mfl) {
-    if(!is.null(options$search_space)) {
-      lowercase_ids <- detect_lowercase_identifiers(options$search_space)
-      if(length(lowercase_ids) > 0 && verbose) {
-        cli::cli_alert_warning(c(
-          "{.code search_space} contains lowercase identifier{?s}: {.val {lowercase_ids}}.",
-          i = "Pharmpy's MFL parser uppercases all identifiers (see {.url https://github.com/pharmpy/pharmpy/issues/4576}); uppercasing now."
-        ))
-      }
-      options$search_space <- toupper(options$search_space)
+  ## uppercase both the search_space string and the model's columns. Only
+  ## applied when an MFL `search_space` is actually being passed, to avoid
+  ## mutating column names for tools that don't consume MFL (bootstrap,
+  ## simulation, etc.).
+  if(uppercase_mfl && !is.null(options$search_space)) {
+    lowercase_ids <- detect_lowercase_identifiers(options$search_space)
+    if(length(lowercase_ids) > 0 && verbose) {
+      cli::cli_alert_warning(c(
+        "{.code search_space} contains lowercase identifier{?s}: {.val {lowercase_ids}}.",
+        i = "Pharmpy's MFL parser uppercases all identifiers (see {.url https://github.com/pharmpy/pharmpy/issues/4576}); uppercasing now."
+      ))
     }
+    options$search_space <- toupper(options$search_space)
     renamed <- uppercase_model_columns(model)
     if(length(renamed$renamed) > 0) {
       if(verbose) {

--- a/R/mfl_uppercase.R
+++ b/R/mfl_uppercase.R
@@ -1,0 +1,49 @@
+## Workarounds for pharmpy's MFL parser, which unconditionally uppercases every
+## identifier in a `search_space` string (see
+## https://github.com/pharmpy/pharmpy/issues/4576). To make tools like covsearch
+## work with datasets that use lowercase column names, we uppercase both the
+## search_space and the model's $INPUT / datainfo / dataset columns to match.
+
+## Return the unique lowercase-containing identifiers found in a search_space
+## string. Used to warn the caller that the MFL parser will uppercase those
+## tokens regardless of what they wrote.
+detect_lowercase_identifiers <- function(search_space) {
+  if (is.null(search_space) || !is.character(search_space)) {
+    return(character(0))
+  }
+  tokens <- unlist(stringr::str_extract_all(
+    search_space, "[A-Za-z_][A-Za-z0-9_]*"
+  ))
+  unique(tokens[stringr::str_detect(tokens, "[a-z]")])
+}
+
+## Uppercase every column name in a pharmpy model: both datainfo (so $INPUT is
+## written uppercase) and the in-memory dataset. Returns a list with the new
+## model and a named character vector of `old = new` renames that were applied.
+##
+## Performed entirely on the Python side via py_run_string to avoid R↔Python
+## auto-conversion stripping the ColumnInfo type from list elements.
+uppercase_model_columns <- function(model) {
+  reticulate::py_run_string("
+def _pharmr_extra_uppercase_model(m):
+    rm = {c.name: c.name.upper()
+          for c in m.datainfo
+          if c.name != c.name.upper()}
+    if not rm:
+        return m, {}
+    cols = tuple(
+        c.replace(name=rm[c.name]) if c.name in rm else c
+        for c in m.datainfo
+    )
+    new_di = m.datainfo.replace(columns=cols)
+    if m.dataset is not None:
+        new_ds = m.dataset.rename(columns=rm)
+        return m.replace(datainfo=new_di, dataset=new_ds), rm
+    return m.replace(datainfo=new_di), rm
+")
+  result <- reticulate::py$`_pharmr_extra_uppercase_model`(model)
+  list(
+    model = result[[1]],
+    renamed = unlist(result[[2]])
+  )
+}

--- a/R/mfl_uppercase.R
+++ b/R/mfl_uppercase.R
@@ -21,9 +21,24 @@ detect_lowercase_identifiers <- function(search_space) {
 ## written uppercase) and the in-memory dataset. Returns a list with the new
 ## model and a named character vector of `old = new` renames that were applied.
 ##
+## Aborts if uppercasing would produce duplicate column names (e.g. the model
+## already contains both `wt` and `WT`), since the rename would silently
+## clobber one of them.
+##
 ## Performed entirely on the Python side via py_run_string to avoid R↔Python
 ## auto-conversion stripping the ColumnInfo type from list elements.
 uppercase_model_columns <- function(model) {
+  names <- model$datainfo$names
+  final_names <- ifelse(names == toupper(names), names, toupper(names))
+  collisions <- unique(final_names[duplicated(final_names)])
+  if(length(collisions) > 0) {
+    offenders <- names[toupper(names) %in% collisions]
+    cli::cli_abort(c(
+      "Uppercasing model columns would create duplicate name{?s}: {.val {collisions}}.",
+      i = "The model already contains columns that differ only by case: {.val {offenders}}.",
+      i = "Resolve manually, or set {.code uppercase_mfl = FALSE} in {.fn call_pharmpy_tool}."
+    ))
+  }
   reticulate::py_run_string("
 def _pharmr_extra_uppercase_model(m):
     rm = {c.name: c.name.upper()

--- a/man/call_pharmpy_tool.Rd
+++ b/man/call_pharmpy_tool.Rd
@@ -15,7 +15,8 @@ call_pharmpy_tool(
   verbose = TRUE,
   force = FALSE,
   options = list(),
-  remove_tables = TRUE
+  remove_tables = TRUE,
+  uppercase_mfl = TRUE
 )
 }
 \arguments{
@@ -43,6 +44,13 @@ https://pharmpy.github.io/latest/mfl.html.}
 
 \item{remove_tables}{if \code{TRUE} (default), removes all \verb{$TABLE} records from the model
 before passing it to the Pharmpy tool.}
+
+\item{uppercase_mfl}{if \code{TRUE} (default), uppercases the model's \verb{$INPUT} /
+datainfo / dataset column names and the \code{options$search_space} string before
+calling the Pharmpy tool. Works around Pharmpy's MFL parser, which
+unconditionally uppercases every identifier in a search_space and then fails
+the case-sensitive lookup against datainfo (see
+\url{https://github.com/pharmpy/pharmpy/issues/4576}). Set to \code{FALSE} to disable.}
 }
 \value{
 fit object

--- a/tests/testthat/test-mfl_uppercase.R
+++ b/tests/testthat/test-mfl_uppercase.R
@@ -1,32 +1,32 @@
 test_that("detect_lowercase_identifiers returns lowercase tokens only", {
   expect_equal(
-    detect_lowercase_identifiers("COVARIATE([CL,V], [wt,age], EXP)"),
+    pharmr.extra:::detect_lowercase_identifiers("COVARIATE([CL,V], [wt,age], EXP)"),
     c("wt", "age")
   )
 })
 
 test_that("detect_lowercase_identifiers returns empty when all uppercase", {
   expect_equal(
-    detect_lowercase_identifiers("COVARIATE([CL,V], [WT,AGE], EXP)"),
+    pharmr.extra:::detect_lowercase_identifiers("COVARIATE([CL,V], [WT,AGE], EXP)"),
     character(0)
   )
 })
 
 test_that("detect_lowercase_identifiers returns empty for NULL or non-character", {
-  expect_equal(detect_lowercase_identifiers(NULL), character(0))
-  expect_equal(detect_lowercase_identifiers(123), character(0))
+  expect_equal(pharmr.extra:::detect_lowercase_identifiers(NULL), character(0))
+  expect_equal(pharmr.extra:::detect_lowercase_identifiers(123), character(0))
 })
 
 test_that("detect_lowercase_identifiers deduplicates repeated tokens", {
   expect_equal(
-    detect_lowercase_identifiers("COVARIATE([cl], [wt], LIN); COVARIATE([cl], [wt], POW)"),
+    pharmr.extra:::detect_lowercase_identifiers("COVARIATE([cl], [wt], LIN); COVARIATE([cl], [wt], POW)"),
     c("cl", "wt")
   )
 })
 
 test_that("detect_lowercase_identifiers flags mixed-case tokens", {
   expect_equal(
-    detect_lowercase_identifiers("COVARIATE([CL], [Weight], EXP)"),
+    pharmr.extra:::detect_lowercase_identifiers("COVARIATE([CL], [Weight], EXP)"),
     "Weight"
   )
 })

--- a/tests/testthat/test-mfl_uppercase.R
+++ b/tests/testthat/test-mfl_uppercase.R
@@ -1,0 +1,32 @@
+test_that("detect_lowercase_identifiers returns lowercase tokens only", {
+  expect_equal(
+    detect_lowercase_identifiers("COVARIATE([CL,V], [wt,age], EXP)"),
+    c("wt", "age")
+  )
+})
+
+test_that("detect_lowercase_identifiers returns empty when all uppercase", {
+  expect_equal(
+    detect_lowercase_identifiers("COVARIATE([CL,V], [WT,AGE], EXP)"),
+    character(0)
+  )
+})
+
+test_that("detect_lowercase_identifiers returns empty for NULL or non-character", {
+  expect_equal(detect_lowercase_identifiers(NULL), character(0))
+  expect_equal(detect_lowercase_identifiers(123), character(0))
+})
+
+test_that("detect_lowercase_identifiers deduplicates repeated tokens", {
+  expect_equal(
+    detect_lowercase_identifiers("COVARIATE([cl], [wt], LIN); COVARIATE([cl], [wt], POW)"),
+    c("cl", "wt")
+  )
+})
+
+test_that("detect_lowercase_identifiers flags mixed-case tokens", {
+  expect_equal(
+    detect_lowercase_identifiers("COVARIATE([CL], [Weight], EXP)"),
+    "Weight"
+  )
+})


### PR DESCRIPTION
## Summary

Works around [pharmpy/pharmpy#4576](https://github.com/pharmpy/pharmpy/issues/4576): the MFL parser unconditionally uppercases every identifier in a `search_space` string, then validates them case-sensitively against `datainfo.names`. Users with lowercase column conventions hit:

```
Invalid `search_space` because of invalid covariate found in search_space:
got `WT`, must be in [..., 'wt'].
```

even though `wt` exists in the model.

## What changed

- New `uppercase_mfl = TRUE` parameter on `call_pharmpy_tool()`. When enabled (default):
  - Detects lowercase identifiers in `options$search_space` and emits a `cli_alert_warning` linking the upstream issue.
  - Uppercases the `search_space` string.
  - Uppercases the model's `$INPUT` / datainfo / dataset column names, with a `cli_alert_info` listing the `old -> new` renames.
- New internal helpers in `R/mfl_uppercase.R`:
  - `detect_lowercase_identifiers()` — pure R token scanner over the MFL string.
  - `uppercase_model_columns()` — performs the rename entirely on the Python side via `py_run_string` to avoid R↔Python `ColumnInfo` conversion stripping the type (which surfaced as `Argument 'columns' need to consist of either type 'str' or 'ColumnInfo'` during development).

The new logic runs after the iivsearch-default-search_space block and before args prep, so it applies uniformly across MFL-consuming tools (covsearch, modelsearch, iivsearch, amd, etc.).

## Notes for reviewers

- The rename uses iteration over `m.datainfo` directly (not `m.datainfo.columns`) because `DataInfo` doesn't expose a public `columns` property — only `_columns`. Iteration is the documented access path.
- Pass `uppercase_mfl = FALSE` to opt out (e.g. if the rest of your pipeline depends on lowercase column names downstream of the tool call).
- Edge case not handled: if a covariate is already referenced in `model.statements` and you rename its column, the sympy symbol in the statement won't auto-update. For covsearch this isn't a concern (the covariate isn't in the model yet); flag if you want explicit handling for other workflows.

## Test plan

- [x] Unit tests for `detect_lowercase_identifiers()` (5 cases) — `devtools::test(filter = "mfl_uppercase")` passes.
- [x] Existing `call_pharmpy_tool` tests still pass.
- [ ] Manual: run `covsearch` on a model with lowercase `$INPUT` and confirm the warning fires and the search completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)