### PR TITLE
Widen VPC $TABLE FORMAT so subject IDs are not truncated

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pharmr.extra
 Title: Extension of pharmr (Pharmpy) functionality
-Version: 0.0.0.9090
+Version: 0.0.0.9091
 Authors@R: c(
     person("Ron", "Keizer", email = "ron@insight-rx.com", role = c("cre", "aut")),
     person("Michael", "McCarthy", email = "michael.mccarthy@insight-rx.com", role = "ctb"),

--- a/R/create_vpc_data.R
+++ b/R/create_vpc_data.R
@@ -120,7 +120,9 @@ create_vpc_data <- function(
   vpc_vars <- unique(vpc_vars)
   model_code <- remove_record(model_code, "COV")     ## matches $COV / $COVA ... / $COVARIANCE
   model_code <- remove_record(model_code, "TABLE")
-  model_code <- add_table_record(model_code, vpc_vars, file = "sdtab")
+
+  ## ensure enough digits for saving unique IDs (this ensures 9 unique digits)
+  model_code <- add_table_record(model_code, vpc_vars, file = "sdtab", format = "sF9.0")
 
   ## Point the model's $DATA at our sanitised CSV so Pharmpy (inside
   ## run_nlme) reads numeric data only.
@@ -460,11 +462,16 @@ remove_record <- function(code, record_name) {
 
 #' Add a $TABLE record at the end of the model code.
 #' @noRd
-add_table_record <- function(code, variables, file = "sdtab") {
+add_table_record <- function(
+    code,
+    variables,
+    file = "sdtab",
+    format = "sF9.0"
+) {
   table_line <- paste(
     "$TABLE",
     paste(variables, collapse = " "),
-    paste0("NOAPPEND NOPRINT FILE=", file)
+    paste0("NOAPPEND NOPRINT FILE=", file, " FORMAT=", format)
   )
   paste0(sub("\\s+$", "", code), "\n", table_line, "\n")
 }

--- a/tests/testthat/test-create_vpc_data.R
+++ b/tests/testthat/test-create_vpc_data.R
@@ -278,6 +278,23 @@ test_that("add_table_record() appends a single $TABLE record", {
   expect_match(out, "\\$TABLE ID TIME PRED NOAPPEND NOPRINT FILE=sdtab")
 })
 
+test_that("add_table_record() sets a wide FORMAT so IDs are not truncated", {
+  ## Regression: NONMEM's default table format is 12.4g, which truncates large
+  ## integer IDs (e.g. 8- or 9-digit subject IDs) to ~6-7 significant digits.
+  ## A wide sF9.0 format preserves the full integer ID in the VPC output.
+  code <- "$PROBLEM t\n$THETA 1\n"
+  out <- pharmr.extra:::add_table_record(code, c("ID", "TIME", "PRED"), file = "sdtab")
+  expect_match(out, "FORMAT=sF9.0")
+})
+
+test_that("add_table_record() honours a custom FORMAT", {
+  code <- "$PROBLEM t\n$THETA 1\n"
+  out <- pharmr.extra:::add_table_record(
+    code, c("ID", "TIME", "PRED"), file = "sdtab", format = "sF12.0"
+  )
+  expect_match(out, "FILE=sdtab FORMAT=sF12.0")
+})
+
 
 # set_estimation_maxeval_zero / convert_estimation_to_simulation -------
 


### PR DESCRIPTION
## Summary
`create_vpc_data()` wrote the sdtab `$TABLE` with NONMEM's default numeric format (`12.4g`), which truncates large integer subject IDs to ~6–7 significant digits. This corrupts IDs in VPC output for datasets with 8–9 digit IDs.

Fix: `add_table_record()` now appends `FORMAT=sF9.0` to the `$TABLE` line (exposed via a new `format` argument), preserving full-width integer IDs.

## Tests
Added two unit tests in `test-create_vpc_data.R`:
- `add_table_record()` emits `FORMAT=sF9.0` by default (regression guard for ID truncation).
- `add_table_record()` honours a custom `format` argument.

🤖 Generated with [Claude Code](https://claude.com/claude-code)