### PR TITLE
Widen add_table_to_model() $TABLE FORMAT so subject IDs are not truncated

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pharmr.extra
 Title: Extension of pharmr (Pharmpy) functionality
-Version: 0.0.0.9091
+Version: 0.0.0.9093
 Authors@R: c(
     person("Ron", "Keizer", email = "ron@insight-rx.com", role = c("cre", "aut")),
     person("Michael", "McCarthy", email = "michael.mccarthy@insight-rx.com", role = "ctb"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pharmr.extra
 Title: Extension of pharmr (Pharmpy) functionality
-Version: 0.0.0.9093
+Version: 0.0.0.9094
 Authors@R: c(
     person("Ron", "Keizer", email = "ron@insight-rx.com", role = c("cre", "aut")),
     person("Michael", "McCarthy", email = "michael.mccarthy@insight-rx.com", role = "ctb"),

--- a/R/add_table_to_model.R
+++ b/R/add_table_to_model.R
@@ -7,7 +7,10 @@
 #' @param reload_dataset should dataset be reloaded into the Pharmpy model object
 #' after updating the model. Default is TRUE, to ensure a proper Pharmpy model object,
 #' but can result in issues.
-#' 
+#' @param format NONMEM `$TABLE` output format. Defaults to `sF9.0`, which keeps
+#' enough digits to write large integer subject IDs without truncation (NONMEM's
+#' default format truncates IDs to ~6-7 significant digits).
+#'
 #' @returns TODO
 #'
 #' @export
@@ -16,7 +19,8 @@ add_table_to_model <- function(
     variables,
     firstonly = FALSE,
     file,
-    reload_dataset = TRUE
+    reload_dataset = TRUE,
+    format = "sF9.0"
 ) {
   check_nm_table_variables(model, variables)
   tool <- get_tool_from_model(model)
@@ -37,6 +41,7 @@ add_table_to_model <- function(
       ifelse(firstonly, "\n  FIRSTONLY", ""),
       "\n  NOAPPEND NOPRINT",
       "\n  FILE=", file,
+      "\n  FORMAT=", format,
       "\n\n"
     )
     model <- pharmr::read_model_from_string(

--- a/R/add_table_to_model.R
+++ b/R/add_table_to_model.R
@@ -40,8 +40,11 @@ add_table_to_model <- function(
       paste0(c(" ", variables), collapse = " "),
       ifelse(firstonly, "\n  FIRSTONLY", ""),
       "\n  NOAPPEND NOPRINT",
-      "\n  FILE=", file,
+      ## FORMAT must precede FILE: remove_table_sections() strips a $TABLE by
+      ## matching up to `FILE=<file>`, so FILE has to stay the last option or
+      ## any trailing option is orphaned and corrupts the next record.
       "\n  FORMAT=", format,
+      "\n  FILE=", file,
       "\n\n"
     )
     model <- pharmr::read_model_from_string(

--- a/man/add_table_to_model.Rd
+++ b/man/add_table_to_model.Rd
@@ -9,7 +9,8 @@ add_table_to_model(
   variables,
   firstonly = FALSE,
   file,
-  reload_dataset = TRUE
+  reload_dataset = TRUE,
+  format = "sF9.0"
 )
 }
 \arguments{
@@ -24,6 +25,10 @@ add_table_to_model(
 \item{reload_dataset}{should dataset be reloaded into the Pharmpy model object
 after updating the model. Default is TRUE, to ensure a proper Pharmpy model object,
 but can result in issues.}
+
+\item{format}{NONMEM \verb{$TABLE} output format. Defaults to \code{sF9.0}, which keeps
+enough digits to write large integer subject IDs without truncation (NONMEM's
+default format truncates IDs to ~6-7 significant digits).}
 }
 \value{
 TODO

--- a/tests/testthat/test-add_table_to_model.R
+++ b/tests/testthat/test-add_table_to_model.R
@@ -18,7 +18,7 @@ test_that("adds table correctly", {
     file = "patab"
   )
   
-  expected_addition <- "\\n\\$TABLE\\n  ID CL V\\n  NOAPPEND NOPRINT\\n  FILE=patab\\n  FORMAT=sF9.0\\n\\n"
+  expected_addition <- "\\n\\$TABLE\\n  ID CL V\\n  NOAPPEND NOPRINT\\n  FORMAT=sF9.0\\n  FILE=patab\\n\\n"
   expect_true(grepl(expected_addition, result$code))
 
   # Test with firstonly = TRUE
@@ -29,7 +29,7 @@ test_that("adds table correctly", {
     file = "patab"
   )
 
-  expected_addition <- "\\n\\$TABLE\\n  ID CL V\\n  FIRSTONLY\\n  NOAPPEND NOPRINT\\n  FILE=patab\\n  FORMAT=sF9.0\\n\\n"
+  expected_addition <- "\\n\\$TABLE\\n  ID CL V\\n  FIRSTONLY\\n  NOAPPEND NOPRINT\\n  FORMAT=sF9.0\\n  FILE=patab\\n\\n"
   expect_true(grepl(expected_addition, result$code))
 })
 

--- a/tests/testthat/test-add_table_to_model.R
+++ b/tests/testthat/test-add_table_to_model.R
@@ -18,9 +18,9 @@ test_that("adds table correctly", {
     file = "patab"
   )
   
-  expected_addition <- "\\n\\$TABLE\\n  ID CL V\\n  NOAPPEND NOPRINT\\n  FILE=patab\\n\\n"
+  expected_addition <- "\\n\\$TABLE\\n  ID CL V\\n  NOAPPEND NOPRINT\\n  FILE=patab\\n  FORMAT=sF9.0\\n\\n"
   expect_true(grepl(expected_addition, result$code))
-  
+
   # Test with firstonly = TRUE
   result <- add_table_to_model(
     model = mod,
@@ -28,9 +28,38 @@ test_that("adds table correctly", {
     firstonly = TRUE,
     file = "patab"
   )
-  
-  expected_addition <- "\\n\\$TABLE\\n  ID CL V\\n  FIRSTONLY\\n  NOAPPEND NOPRINT\\n  FILE=patab\\n\\n"
+
+  expected_addition <- "\\n\\$TABLE\\n  ID CL V\\n  FIRSTONLY\\n  NOAPPEND NOPRINT\\n  FILE=patab\\n  FORMAT=sF9.0\\n\\n"
   expect_true(grepl(expected_addition, result$code))
+})
+
+test_that("adds a wide FORMAT so subject IDs are not truncated", {
+  ## Regression: NONMEM's default table format truncates large integer IDs to
+  ## ~6-7 significant digits. add_table_to_model() must emit an explicit FORMAT
+  ## wide enough to preserve full 8-9 digit IDs in simulation/output tables.
+  dat <- data.frame(
+    ID = 1,
+    TIME = c(0, 1, 2),
+    DV = c(0, 10, 5),
+    AMT = c(100, 0, 0),
+    CMT = 1,
+    EVID = c(1, 0, 0),
+    MDV = c(1, 0, 0)
+  )
+  mod <- create_model(route = "iv", data = dat, tables = NULL, verbose = FALSE)
+
+  # Default format
+  result <- add_table_to_model(
+    model = mod, variables = c("ID", "CL", "V"), file = "patab"
+  )
+  expect_true(grepl("FORMAT=sF9.0", result$code, fixed = TRUE))
+
+  # Custom format is honoured
+  result2 <- add_table_to_model(
+    model = mod, variables = c("ID", "CL", "V"), file = "patab",
+    format = "sF12.0"
+  )
+  expect_true(grepl("FORMAT=sF12.0", result2$code, fixed = TRUE))
 })
 
 test_that("warns on duplicate file", {


### PR DESCRIPTION
## Summary
`add_table_to_model()` wrote `$TABLE` records with NONMEM's default numeric format, which truncates large integer subject IDs to ~6–7 significant digits. This affects every caller:
- `run_sim.R` — simulation sdtab
- `add_default_output_tables.R` — default fit output tables
- pk tables (`update_pk_tables.R` / `call_pharmpy_tool.R`)

Fix: add a `format` argument (default `sF9.0`) and emit `FORMAT=` on the `$TABLE` record, preserving full-width integer IDs.

Mirrors the same fix applied to `create_vpc_data()`'s `add_table_record()` in #105.

## Tests
`test-add_table_to_model.R`:
- Updated the two existing expected-string assertions to include `FORMAT=sF9.0`.
- Added a regression test: default emits `FORMAT=sF9.0`, and a custom `format` arg is honoured.

Docs regenerated (`man/add_table_to_model.Rd`), version bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)