### PR TITLE
Do not strip commas from a leading comment before $INPUT

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pharmr.extra
 Title: Extension of pharmr (Pharmpy) functionality
-Version: 0.0.0.9091
+Version: 0.0.0.9092
 Authors@R: c(
     person("Ron", "Keizer", email = "ron@insight-rx.com", role = c("cre", "aut")),
     person("Michael", "McCarthy", email = "michael.mccarthy@insight-rx.com", role = "ctb"),

--- a/R/create_model_from_file.R
+++ b/R/create_model_from_file.R
@@ -111,7 +111,7 @@ create_model_from_file <- function(
 #'
 #' @returns Character string with model code.
 strip_input_commas <- function(text) {
-  gsub("(?:\\$INPUT\\b|\\G)[^,$]*\\K,", " ", text, perl = TRUE)
+  gsub("(?:\\$INPUT\\b|(?!\\A)\\G)[^,$]*\\K,", " ", text, perl = TRUE)
 }
 
 #' Guard against a bug in Pharmpy where eta_dummy is not correctly imported

--- a/tests/testthat/test-create_model_from_file.R
+++ b/tests/testthat/test-create_model_from_file.R
@@ -254,3 +254,10 @@ test_that("strip_input_commas handles multi-line $INPUT", {
   expect_true(grepl("$INPUT ID  TIME \n  DV  AMT", out, fixed = TRUE))
   expect_true(grepl("$DATA data.csv, IGNORE=@", out, fixed = TRUE))
 })
+
+test_that("strip_input_commas leaves commas in a leading comment untouched", {
+  code <- "; PK model, final\n$PROBLEM Test\n$INPUT ID, TIME, DV"
+  out <- strip_input_commas(code)
+  expect_true(grepl("; PK model, final", out, fixed = TRUE))
+  expect_true(grepl("$INPUT ID  TIME  DV", out, fixed = TRUE))
+})


### PR DESCRIPTION
## Summary
Follow-up to #104. `strip_input_commas()` anchored its `\G` continuation at the string start (`\A`), so a model file that opened with a comma-containing comment line (e.g. `; PK model, final`) had those commas turned into spaces before the `$INPUT` record was even reached.

Fix: anchor the continuation alternative with `(?!\A)\G` so `\G` only chains from a prior `$INPUT` match. Text before `$INPUT` (comments, `$PROBLEM`) is left untouched.

## Tests
`test-create_model_from_file.R`: added a case asserting a leading `; PK model, final` comment keeps its commas while `$INPUT ID, TIME, DV` is still normalised to spaces. Existing multi-line `$INPUT` / `$DATA` comma-preservation cases still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)