### PR TITLE
fix: run_sim() path forwarding and per-regimen run folders (#116)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pharmr.extra
 Title: Extension of pharmr (Pharmpy) functionality
-Version: 0.0.0.9110
+Version: 0.0.0.9111
 Authors@R: c(
     person("Ron", "Keizer", email = "ron@insight-rx.com", role = c("cre", "aut")),
     person("Michael", "McCarthy", email = "michael.mccarthy@insight-rx.com", role = "ctb"),

--- a/R/create_run_folder.R
+++ b/R/create_run_folder.R
@@ -25,7 +25,9 @@ create_run_folder <- function(
       cli::cli_abort(paste0("Run folder (", fit_folder, ") exists. Use `force` to overwrite."))
     }
   } else {
-    dir.create(fit_folder)
+    ## recursive so nested ids (e.g. `run1/regimen_2` from run_sim) create
+    ## any missing parent folders instead of failing.
+    dir.create(fit_folder, recursive = TRUE)
   }
   fit_folder
 }

--- a/R/run_nlme.R
+++ b/R/run_nlme.R
@@ -451,6 +451,10 @@ run_nlme <- function(
   time_all <- round(as.numeric(time_end - time_start), 1)
   if(verbose) cli::cli_alert_success(paste0("Run done (", time_all,"s)."))
 
+  ## Expose the resolved run folder so callers (e.g. run_sim) can locate
+  ## on-disk output without re-deriving it from `path`/`id` defaults.
+  attr(fit, "fit_folder") <- obj$fit_folder
+
   fit
 
 }

--- a/R/run_sim.R
+++ b/R/run_sim.R
@@ -40,6 +40,9 @@
 #' @param variables vector of variables to output. If `NULL`, will output
 #' default variables `c("ID", "TIME", "DV", "EVID", "PRED")` as well as
 #' all variables declared in the NONMEM code.
+#' @param path folder in which to create the run folder(s). Each regimen is
+#' run in its own subfolder `id/regimen_<i>`. If `NULL` (default), the folder
+#' is forwarded to [run_nlme()] unset, so `run_nlme()`'s own default applies.
 #' @param output_file TODO
 #' @param seed TODO
 #'
@@ -51,6 +54,7 @@ run_sim <- function(
     data = NULL,
     model = NULL,
     id = irxutils::get_random_id("sim_"),
+    path = NULL,
     force = FALSE,
     tool = c("auto", "nonmem", "nlmixr2"),
     n_iterations = 1,
@@ -142,6 +146,7 @@ run_sim <- function(
       data = data,
       model = model,
       id = id,
+      path = path,
       n_iterations = n_iterations,
       variables = variables,
       add_pk_variables = add_pk_variables,
@@ -174,8 +179,13 @@ run_sim <- function(
   unique_regimens <- unique(sim_data[[".regimen"]])
   comb <- list()
 
-  ## Loop over regimens to simulate
-  for(reg_label in unique_regimens) {
+  ## Loop over regimens to simulate. Each regimen gets its own run folder
+  ## (`id/regimen_<i>`) so regimens don't overwrite each other's output.
+  ## Numeric indexing avoids sanitizing user labels that may contain spaces
+  ## NONMEM cannot handle in `$DATA` paths.
+  for(i in seq_along(unique_regimens)) {
+    reg_label <- unique_regimens[i]
+    id_i <- file.path(id, paste0("regimen_", i))
 
     ## grab data for regimen
     sim_data_regimen <- sim_data |>
@@ -235,16 +245,19 @@ run_sim <- function(
     ## Run simulation
     if(verbose) cli::cli_alert_info("Running simulation ({reg_label})")
 
-    ## sim_data_regimen
-    results <- run_nlme(
+    ## sim_data_regimen. Forward `path` only when set, so run_nlme()'s own
+    ## default applies otherwise (decoupled from any getwd() default here).
+    nlme_args <- list(
       model = sim_model,
       data = new_dataset_file,
-      id = id,
+      id = id_i,
       force = TRUE,
       copy_dataset = TRUE,
       auto_stack_encounters = FALSE,
       verbose = FALSE
     )
+    if(!is.null(path)) nlme_args$path <- path
+    results <- do.call(run_nlme, nlme_args)
 
     ## Detect silent NONMEM failures: pharmpy/run_nlme do not raise when a
     ## simulation produces no output table, so we check here and surface the
@@ -254,7 +267,8 @@ run_sim <- function(
     if(is.null(sim_tab) || nrow(sim_tab) == 0) {
       abort_on_failed_sim(
         regimen_label = reg_label,
-        fit_folder = file.path(getwd(), id)
+        fit_folder = attr(results, "fit_folder") %||%
+          file.path(path %||% getwd(), id_i)
       )
     }
 

--- a/R/run_sim.R
+++ b/R/run_sim.R
@@ -1,6 +1,9 @@
 #' Run simulations
 #'
 #' @inheritParams run_nlme
+#' @param id base run id (default a random `sim_*`). Each regimen is run in its
+#' own subfolder `id/regimen_<i>` (`<i>` = 1-based regimen index), so regimens
+#' don't overwrite each other's output.
 #' @param model either a Pharmpy model object, or a filename (for a model
 #' with NONMEM model code). If the latter, `run_sim()` will attempt to load the
 #' model into Pharmpy first.

--- a/R/run_sim_nlmixr.R
+++ b/R/run_sim_nlmixr.R
@@ -14,6 +14,9 @@
 #' prediction); rxSolve does not produce both in a single call.
 #'
 #' @inheritParams run_sim
+#' @param path ignored for the nlmixr2 backend: simulations run via
+#' [rxode2::rxSolve()] and create no NONMEM-style run folders. Accepted only to
+#' keep the signature aligned with [run_sim()].
 #' @keywords internal
 run_sim_nlmixr <- function(
   fit = NULL,

--- a/R/run_sim_nlmixr.R
+++ b/R/run_sim_nlmixr.R
@@ -20,6 +20,7 @@ run_sim_nlmixr <- function(
   data = NULL,
   model = NULL,
   id = irxutils::get_random_id("sim_"),
+  path = NULL,
   n_iterations = 1,
   variables = NULL,
   add_pk_variables = FALSE,

--- a/man/run_sim.Rd
+++ b/man/run_sim.Rd
@@ -33,10 +33,9 @@ attached to \code{model} is used as-is.}
 with NONMEM model code). If the latter, \code{run_sim()} will attempt to load the
 model into Pharmpy first.}
 
-\item{id}{run id, e.g. \code{run1}. This will be the folder in which the NONMEM
-model is run. If no folder is specified, it will create a folder \code{run1} in
-the current working directory, and will increment the run number for each
-subsequent run.}
+\item{id}{base run id (default a random \verb{sim_*}). Each regimen is run in its
+own subfolder \verb{id/regimen_<i>} (\verb{<i>} = 1-based regimen index), so regimens
+don't overwrite each other's output.}
 
 \item{path}{folder in which to create the run folder(s). Each regimen is
 run in its own subfolder \verb{id/regimen_<i>}. If \code{NULL} (default), the folder

--- a/man/run_sim.Rd
+++ b/man/run_sim.Rd
@@ -9,6 +9,7 @@ run_sim(
   data = NULL,
   model = NULL,
   id = irxutils::get_random_id("sim_"),
+  path = NULL,
   force = FALSE,
   tool = c("auto", "nonmem", "nlmixr2"),
   n_iterations = 1,
@@ -36,6 +37,10 @@ model into Pharmpy first.}
 model is run. If no folder is specified, it will create a folder \code{run1} in
 the current working directory, and will increment the run number for each
 subsequent run.}
+
+\item{path}{folder in which to create the run folder(s). Each regimen is
+run in its own subfolder \verb{id/regimen_<i>}. If \code{NULL} (default), the folder
+is forwarded to \code{\link[=run_nlme]{run_nlme()}} unset, so \code{run_nlme()}'s own default applies.}
 
 \item{force}{if run folder (\code{id}) exists, should existing results be
 removed before rerunning NONMEM? Default \code{FALSE}.}

--- a/man/run_sim_nlmixr.Rd
+++ b/man/run_sim_nlmixr.Rd
@@ -9,6 +9,7 @@ run_sim_nlmixr(
   data = NULL,
   model = NULL,
   id = irxutils::get_random_id("sim_"),
+  path = NULL,
   n_iterations = 1,
   variables = NULL,
   add_pk_variables = FALSE,
@@ -32,6 +33,10 @@ model into Pharmpy first.}
 model is run. If no folder is specified, it will create a folder \code{run1} in
 the current working directory, and will increment the run number for each
 subsequent run.}
+
+\item{path}{folder in which to create the run folder(s). Each regimen is
+run in its own subfolder \verb{id/regimen_<i>}. If \code{NULL} (default), the folder
+is forwarded to \code{\link[=run_nlme]{run_nlme()}} unset, so \code{run_nlme()}'s own default applies.}
 
 \item{n_iterations}{number of iterations of the entire simulation to
 perform. The dataset for the simulation will stay the same between each

--- a/man/run_sim_nlmixr.Rd
+++ b/man/run_sim_nlmixr.Rd
@@ -29,14 +29,13 @@ attached to \code{model} is used as-is.}
 with NONMEM model code). If the latter, \code{run_sim()} will attempt to load the
 model into Pharmpy first.}
 
-\item{id}{run id, e.g. \code{run1}. This will be the folder in which the NONMEM
-model is run. If no folder is specified, it will create a folder \code{run1} in
-the current working directory, and will increment the run number for each
-subsequent run.}
+\item{id}{base run id (default a random \verb{sim_*}). Each regimen is run in its
+own subfolder \verb{id/regimen_<i>} (\verb{<i>} = 1-based regimen index), so regimens
+don't overwrite each other's output.}
 
-\item{path}{folder in which to create the run folder(s). Each regimen is
-run in its own subfolder \verb{id/regimen_<i>}. If \code{NULL} (default), the folder
-is forwarded to \code{\link[=run_nlme]{run_nlme()}} unset, so \code{run_nlme()}'s own default applies.}
+\item{path}{ignored for the nlmixr2 backend: simulations run via
+\code{\link[rxode2:rxSolve]{rxode2::rxSolve()}} and create no NONMEM-style run folders. Accepted only to
+keep the signature aligned with \code{\link[=run_sim]{run_sim()}}.}
 
 \item{n_iterations}{number of iterations of the entire simulation to
 perform. The dataset for the simulation will stay the same between each

--- a/tests/testthat/test-create_run_folder.R
+++ b/tests/testthat/test-create_run_folder.R
@@ -37,6 +37,16 @@ test_that("works with nested path structures", {
   expect_equal(out, file.path(nested_path, "nested_run"))
 })
 
+test_that("creates missing parent folders when id is nested (e.g. run_sim regimens)", {
+  tmp_dir <- withr::local_tempdir()
+  ## id carrying a subfolder, as run_sim() uses for per-regimen output
+  out <- create_run_folder(id = file.path("sim1", "regimen_2"),
+                           path = tmp_dir, verbose = FALSE)
+
+  expect_true(dir.exists(out))
+  expect_equal(out, file.path(tmp_dir, "sim1", "regimen_2"))
+})
+
 test_that("errors when folder exists and force is FALSE", {
   tmp_dir <- withr::local_tempdir()
   existing_folder <- file.path(tmp_dir, "existing_run")

--- a/tests/testthat/test-run_sim.R
+++ b/tests/testthat/test-run_sim.R
@@ -508,6 +508,74 @@ test_that("run_sim (stub): add_pk_variables=TRUE computes AUC_SS when CL in outp
   expect_equal(unique(out$AUC_SS), 100 / 2) # last dose / CL
 })
 
+test_that("run_sim (stub): each regimen runs in its own id/regimen_<i> folder", {
+  local_pharmr.extra_options()
+  skip_if_nonmem_not_available()
+  withr::local_dir(tempdir())
+
+  mod <- make_model_without_cov()
+  seen_ids <- character(0)
+  local_mocked_bindings(
+    run_nlme = function(id, ...) {
+      seen_ids[[length(seen_ids) + 1L]] <<- id
+      .mock_nlme_result()
+    },
+    .package = "pharmr.extra"
+  )
+  dat <- rbind(
+    cbind(.sim_dat(), .regimen = "100mg"),
+    cbind(.sim_dat(), .regimen = "200mg")
+  )
+  run_sim(model = mod, id = "sim1", data = dat, verbose = FALSE)
+
+  ## distinct, numerically-indexed subfolders — regimens don't overwrite
+  expect_setequal(
+    seen_ids,
+    c(file.path("sim1", "regimen_1"), file.path("sim1", "regimen_2"))
+  )
+})
+
+test_that("run_sim (stub): path is forwarded to run_nlme when set", {
+  local_pharmr.extra_options()
+  skip_if_nonmem_not_available()
+  withr::local_dir(tempdir())
+
+  mod <- make_model_without_cov()
+  seen_path <- new.env()
+  seen_path$val <- "unset"
+  local_mocked_bindings(
+    run_nlme = function(id, path = NULL, ...) {
+      seen_path$val <- path
+      .mock_nlme_result()
+    },
+    .package = "pharmr.extra"
+  )
+  target <- file.path(tempdir(), "custom_sim_out")
+  run_sim(model = mod, id = "sim1", path = target, data = .sim_dat(),
+          verbose = FALSE)
+  expect_equal(seen_path$val, target)
+})
+
+test_that("run_sim (stub): path=NULL (default) is not passed to run_nlme", {
+  local_pharmr.extra_options()
+  skip_if_nonmem_not_available()
+  withr::local_dir(tempdir())
+
+  mod <- make_model_without_cov()
+  seen_path <- new.env()
+  seen_path$val <- "sentinel"
+  local_mocked_bindings(
+    ## default keeps the sentinel, so we can tell whether `path` was supplied
+    run_nlme = function(id, path = "sentinel", ...) {
+      seen_path$val <- path
+      .mock_nlme_result()
+    },
+    .package = "pharmr.extra"
+  )
+  run_sim(model = mod, id = "sim1", data = .sim_dat(), verbose = FALSE)
+  expect_equal(seen_path$val, "sentinel")
+})
+
 test_that("sample_uncertainty_parameters draws from a real covariance matrix", {
   local_pharmr.extra_options()
   skip_if_nonmem_not_available()


### PR DESCRIPTION
Fixes #116.

## Problem
- **No `path` forwarding.** `run_sim()` never accepted/forwarded a `path`, so run folders always landed under `getwd()`.
- **Multi-regimen overwrites.** The regimen loop reused a single `id` with `force = TRUE`, so each regimen wiped the previous run folder (`run.mod`, `run.lst`, `data.csv`) — only the last regimen's on-disk output survived, and a failed early regimen's error folder was gone before `abort_on_failed_sim()` could read it.

## Changes
- Add `path = NULL` to `run_sim()` / `run_sim_nlmixr()`. Forwarded to `run_nlme()` **only when set**, so `run_nlme()`'s own default applies otherwise (decoupled from a hardcoded `getwd()`, per issue discussion).
- Each regimen runs in its own `id/regimen_<i>` folder. Numeric indexing avoids sanitizing user labels containing spaces that NONMEM rejects in `$DATA` paths.
- `run_nlme()` attaches `attr(fit, "fit_folder")`; `run_sim()` resolves the abort folder from it instead of hardcoding `file.path(getwd(), id)`.
- `create_run_folder()` now creates parent folders recursively, so nested ids work (caught by the multi-regimen NONMEM test).

## Tests (run in pmx container w/ NONMEM + pharmpy)
- `run_sim`: 99 pass · `run_nlme`: 103 pass · `create_run_folder`: 12 pass — all 0 fail / 0 skip.
- New: per-regimen folder ids, `path` forwarded when set, `path=NULL` not passed, nested-folder unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)