### PR TITLE
fix: make fit$residuals joinable to the dataset (#120)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pharmr.extra
 Title: Extension of pharmr (Pharmpy) functionality
-Version: 0.0.0.9113
+Version: 0.0.0.9114
 Authors@R: c(
     person("Ron", "Keizer", email = "ron@insight-rx.com", role = c("cre", "aut")),
     person("Michael", "McCarthy", email = "michael.mccarthy@insight-rx.com", role = "ctb"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pharmr.extra
 Title: Extension of pharmr (Pharmpy) functionality
-Version: 0.0.0.9116
+Version: 0.0.0.9117
 Authors@R: c(
     person("Ron", "Keizer", email = "ron@insight-rx.com", role = c("cre", "aut")),
     person("Michael", "McCarthy", email = "michael.mccarthy@insight-rx.com", role = "ctb"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pharmr.extra
 Title: Extension of pharmr (Pharmpy) functionality
-Version: 0.0.0.9114
+Version: 0.0.0.9115
 Authors@R: c(
     person("Ron", "Keizer", email = "ron@insight-rx.com", role = c("cre", "aut")),
     person("Michael", "McCarthy", email = "michael.mccarthy@insight-rx.com", role = "ctb"),
@@ -53,3 +53,4 @@ Config/testthat/edition: 3
 VignetteBuilder: knitr
 URL: https://insightrx.github.io/pharmr.extra/
 Config/roxygen2/version: 8.0.0
+RoxygenNote: 7.3.3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pharmr.extra
 Title: Extension of pharmr (Pharmpy) functionality
-Version: 0.0.0.9115
+Version: 0.0.0.9116
 Authors@R: c(
     person("Ron", "Keizer", email = "ron@insight-rx.com", role = c("cre", "aut")),
     person("Michael", "McCarthy", email = "michael.mccarthy@insight-rx.com", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,19 @@
 # pharmr.extra (development version)
 
+* `run_nlme()` fits now return a `residuals` element that can be joined to the
+  dataset (#120). Pharmpy returns residuals indexed by dataset row label and
+  drops every row whose residual columns are all exactly 0 — reticulate then
+  drops the index on conversion, so `fit$residuals` reached R with neither a
+  join key nor a row count matching the observation records (1134 vs 2184 in
+  the admiral popPK example). `residuals` is now rebuilt from the run's output
+  tables with one row per observation record — matching
+  `fit$predictions |> filter(MDV == 0)` — plus `ROW` (row number in
+  `model$dataset`), `ID` and `TIME` key columns, and all residual columns
+  written to the tables (`CWRES`, `CIWRES`, `NPDE`, ...). Rows NONMEM reported
+  as 0 are kept. For NONMEM fits the pandas index is still set to the
+  `model$dataset` row labels, so Pharmpy tools that join on it (plots,
+  `ruvsearch`) are unaffected. nlmixr2 fits get the same shape.
+
 * `$TABLE` records written by `add_table_to_model()`, `add_default_output_tables()`,
   `run_sim()` and `create_vpc_data()` no longer round every output column to a
   whole number (#114, a regression in 0.0.0.9092). Those functions widened the

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,13 +6,26 @@
   drops the index on conversion, so `fit$residuals` reached R with neither a
   join key nor a row count matching the observation records (1134 vs 2184 in
   the admiral popPK example). `residuals` is now rebuilt from the run's output
-  tables with one row per observation record — matching
-  `fit$predictions |> filter(MDV == 0)` — plus `ROW` (row number in
-  `model$dataset`), `ID` and `TIME` key columns, and all residual columns
-  written to the tables (`CWRES`, `CIWRES`, `NPDE`, ...). Rows NONMEM reported
-  as 0 are kept. For NONMEM fits the pandas index is still set to the
-  `model$dataset` row labels, so Pharmpy tools that join on it (plots,
-  `ruvsearch`) are unaffected. nlmixr2 fits get the same shape.
+  tables with one row per observation record — the rows of `fit$predictions`
+  for which `model$dataset$MDV == 0` — plus `ROW` (row number in
+  `model$dataset`) and the model's ID and independent-variable columns (`ID`
+  and `TIME` for a typical NONMEM dataset; the names are taken from the
+  model's datainfo) as join keys, and all residual columns written to the
+  tables (`CWRES`, `CIWRES`, `NPDE`, ...). So
+
+  ``` r
+  dplyr::left_join(
+    dplyr::mutate(model$dataset, ROW = dplyr::row_number()),
+    fit$residuals,
+    by = "ROW"
+  )
+  ```
+
+  attaches the residuals to the dataset. Rows NONMEM reported as 0 are kept.
+  For NONMEM fits the pandas index is still set to the `model$dataset` row
+  labels, so Pharmpy tools that join on it (plots, `ruvsearch`) are
+  unaffected. nlmixr2 fits get the same shape, keyed against the data they
+  were actually fitted to.
 
 * `$TABLE` records written by `add_table_to_model()`, `add_default_output_tables()`,
   `run_sim()` and `create_vpc_data()` no longer round every output column to a

--- a/R/attach_fit_info.R
+++ b/R/attach_fit_info.R
@@ -3,10 +3,21 @@
 #'
 #' @inheritParams run_nlme
 #' @inheritParams get_fit_info
-#' @param fit_folder TODO
-#' @param is_sim_model TODO
+#' @param fit_folder Folder the run was executed in, holding the output
+#'   tables and the estimation output file.
+#' @param is_sim_model Is `fit` the result of a simulation rather than an
+#'   estimation? Simulation results have no fit summary and no residuals to
+#'   repair.
 #'
-#' @returns TODO
+#' @returns The fit object with the model, the output tables and (for
+#'   estimation runs) a fit summary attached as the `model`, `tables` and
+#'   `info` attributes, and with `residuals` rebuilt into a joinable frame
+#'   (see the `Value` section of [run_nlme()]).
+#'
+#'   Note that for a Pharmpy fit this is a *new* object — `ModelfitResults` is
+#'   a frozen dataclass, so replacing `residuals` means replacing the object.
+#'   Attributes already set on the fit passed in are carried over, but any
+#'   reference the caller still holds points at the un-repaired fit.
 #'
 #' @export
 attach_fit_info <- function(

--- a/R/attach_fit_info.R
+++ b/R/attach_fit_info.R
@@ -17,17 +17,27 @@ attach_fit_info <- function(
   is_sim_model = FALSE,
   verbose = TRUE
 ) {
-  ## Attach model object (with dataset) to fit, for traceability or use in post-processing
-  attr(fit, "model") <- model
-
-  ## Attach tables to model fit
+  ## Read tables from the run folder
   if(verbose) cli::cli_process_start("Importing generated tables")
   tables <- get_tables_from_fit(
     model,
     fit_folder
   )
-  attr(fit, "tables") <- tables
   if(verbose) cli::cli_process_done()
+
+  ## Rebuild `residuals` so it is aligned with the observation records and
+  ## carries join keys (see repair_residuals()). Must happen before the
+  ## attributes are set: for Pharmpy fits this returns a new (immutable)
+  ## results object, which would not carry attributes set on the old one.
+  if(!is_sim_model) {
+    fit <- repair_residuals(fit, model, tables, verbose = verbose)
+  }
+
+  ## Attach model object (with dataset) to fit, for traceability or use in post-processing
+  attr(fit, "model") <- model
+
+  ## Attach tables to model fit
+  attr(fit, "tables") <- tables
 
   if(!is_sim_model) {
     ## Generate a summary of fit info

--- a/R/repair_residuals.R
+++ b/R/repair_residuals.R
@@ -12,22 +12,112 @@ residual_column_names <- function() {
   )
 }
 
+#' Normalize a key column to a character vector that survives table round-trip
+#'
+#' NONMEM writes table columns at ~5 significant digits (`1PE11.4`), so a
+#' dataset `TIME` of `0.0833333` comes back from the table as `8.33330E-02`.
+#' Pasting the raw values would never match, so both sides are rounded to 5
+#' significant digits first. Character columns that hold numbers (`"001"` vs
+#' `1`) are coerced the same way, so an ID read as character still matches an
+#' ID read as numeric.
+#'
+#' @noRd
+normalize_key_column <- function(x) {
+  if(is.factor(x)) x <- as.character(x)
+  if(is.numeric(x)) {
+    ## as.character() formats element-wise, unlike format(), so two vectors
+    ## with different value ranges still produce comparable strings.
+    return(as.character(signif(x, 5)))
+  }
+  chr <- trimws(as.character(x))
+  num <- suppressWarnings(as.numeric(chr))
+  if(!any(is.na(num) & !is.na(chr) & chr != "")) {
+    return(as.character(signif(num, 5)))
+  }
+  chr
+}
+
+#' Build the ID/IDV record key used to align a table with the dataset
+#'
+#' @noRd
+record_key <- function(id, idv) {
+  paste(normalize_key_column(id), normalize_key_column(idv), sep = "\r")
+}
+
+#' Make a record key unique by appending the occurrence number
+#'
+#' Datasets legitimately repeat ID/IDV pairs (e.g. two analytes measured at the
+#' same time). Numbering the occurrences keeps [base::match()] from collapsing
+#' them all onto the first table row: the n-th record with a given key is
+#' matched to the n-th table row with that key.
+#'
+#' @noRd
+disambiguate_key <- function(key) {
+  if(!anyDuplicated(key)) return(key)
+  paste(key, stats::ave(seq_along(key), key, FUN = seq_along), sep = "\r")
+}
+
+#' Take the last block of a table that holds several stacked repetitions
+#'
+#' [read_table_nm()] skips only the *first* `TABLE NO.` header and `na.omit()`s
+#' the rest, so a `$TABLE` file written by a multi-step estimation (e.g. SAEM
+#' followed by IMP) comes back as several copies of the table stacked on top of
+#' each other. The last block is the one from the final estimation step.
+#'
+#' @param tab Table as read from the run folder.
+#' @param lengths Candidate block lengths, most specific first.
+#'
+#' @noRd
+last_table_block <- function(tab, lengths) {
+  n <- nrow(tab)
+  ## An exact match is a single block, never a stack — check before looking
+  ## for multiples (a 6-record dataset with 3 observations would otherwise
+  ## have its 6-row table cut down to the last 3 rows).
+  if(n %in% lengths) return(tab)
+  for(len in lengths) {
+    if(len > 0 && n > len && n %% len == 0) {
+      return(tab[seq.int(n - len + 1, n), , drop = FALSE])
+    }
+  }
+  tab
+}
+
+#' Does a table carry both key columns?
+#'
+#' @noRd
+has_key_columns <- function(tab, id_col, idv_col) {
+  all(c(id_col, idv_col) %in% names(tab))
+}
+
 #' Build a joinable residuals frame from a fit's output tables
 #'
 #' Returns one row per observation record of `dataset`, with the row number in
 #' `dataset` (`ROW`), the ID and independent-variable columns as join keys, and
 #' every residual column found in `tables`.
 #'
-#' Tables are matched against the dataset in three ways, in order:
+#' Tables written by a multi-step estimation hold several stacked copies of the
+#' table (see [last_table_block()]); only the final block is used.
+#'
+#' Tables are then matched against the dataset in three ways, in order:
 #'   1. one row per dataset record (the NONMEM `$TABLE` convention) — the
 #'      observation rows are subset out;
 #'   2. one row per observation record (the `as.data.frame(nlmixr2fit)`
 #'      convention) — used as-is;
 #'   3. otherwise, aligned on the ID/IDV key (NA where a record has no
-#'      matching table row). Only the first match is used per key, so this
-#'      degrades to NA rather than guessing when keys are duplicated, and the
-#'      table is ignored altogether when fewer than half the observation
-#'      records are found (i.e. it isn't from this run).
+#'      matching table row).
+#'
+#' Options 1 and 2 bind positionally, so when the table carries the key columns
+#' the key is verified first and alignment falls through to option 3 on
+#' mismatch (`as.data.frame(nlmixr2fit)` returns rows in ID-sorted order, which
+#' need not be the dataset order). Keys are compared at 5 significant digits,
+#' the precision NONMEM writes tables at, and repeated ID/IDV pairs are matched
+#' in order of occurrence. A table in which fewer than half the observation
+#' records are found is ignored altogether (i.e. it isn't from this run).
+#'
+#' The row-number column is named `ROW` unless `dataset` already has a column
+#' of that name, in which case `.ROW` is used and a warning is issued — joining
+#' the dataset's own `ROW` values against row numbers would silently mismatch.
+#' The name used is returned as the `row_col` attribute of the result.
 #'
 #' Returns `NULL` when no residual column can be located, so callers can leave
 #' the fit untouched.
@@ -37,13 +127,15 @@ residual_column_names <- function() {
 #'   [get_tables_from_fit()].
 #' @param id_col Name of the ID column in `dataset` and the tables.
 #' @param idv_col Name of the independent variable (time) column.
+#' @param verbose Verbose output?
 #'
 #' @noRd
 build_keyed_residuals <- function(
   dataset,
   tables,
   id_col = "ID",
-  idv_col = "TIME"
+  idv_col = "TIME",
+  verbose = FALSE
 ) {
   if(is.null(dataset) || !is.data.frame(dataset) || nrow(dataset) == 0) {
     return(NULL)
@@ -55,37 +147,85 @@ build_keyed_residuals <- function(
   if(is.null(obs_idx)) obs_idx <- seq_len(nrow(dataset))
   if(length(obs_idx) == 0) return(NULL)
 
-  has_key <- all(c(id_col, idv_col) %in% names(dataset))
+  has_key <- has_key_columns(dataset, id_col, idv_col)
   if(has_key) {
-    key_obs <- paste(dataset[[id_col]][obs_idx], dataset[[idv_col]][obs_idx])
+    key_obs <- record_key(
+      dataset[[id_col]][obs_idx],
+      dataset[[idv_col]][obs_idx]
+    )
+    key_obs_uniq <- disambiguate_key(key_obs)
   }
 
   res_cols <- list()
-  for(tab in tables) {
+  for(i in seq_along(tables)) {
+    tab <- tables[[i]]
     if(!is.data.frame(tab) || nrow(tab) == 0) next
     cols <- setdiff(
       intersect(residual_column_names(), names(tab)),
       names(res_cols)
     )
     if(length(cols) == 0) next
+
+    ## Multi-step estimations stack one copy of the table per step; keep the
+    ## last (i.e. the final estimation step).
+    n_before <- nrow(tab)
+    tab <- last_table_block(tab, c(nrow(dataset), length(obs_idx)))
+    if(verbose && nrow(tab) < n_before) {
+      tab_label <- names(tables)[i]
+      if(is.null(tab_label) || is.na(tab_label) || tab_label == "") {
+        tab_label <- as.character(i)
+      }
+      cli::cli_alert_info(
+        "Table {.val {tab_label}} holds {n_before / nrow(tab)} stacked copies (multi-step estimation); using the last."
+      )
+    }
+
+    tab_has_key <- has_key && has_key_columns(tab, id_col, idv_col)
+    vals <- NULL
     if(nrow(tab) == nrow(dataset)) {
-      vals <- tab[obs_idx, cols, drop = FALSE]
-    } else if(nrow(tab) == length(obs_idx)) {
-      vals <- tab[, cols, drop = FALSE]
-    } else if(has_key && all(c(id_col, idv_col) %in% names(tab))) {
-      idx <- match(key_obs, paste(tab[[id_col]], tab[[idv_col]]))
+      ok <- !tab_has_key ||
+        identical(
+          record_key(
+            tab[[id_col]][obs_idx],
+            tab[[idv_col]][obs_idx]
+          ),
+          key_obs
+        )
+      if(ok) vals <- tab[obs_idx, cols, drop = FALSE]
+    }
+    if(is.null(vals) && nrow(tab) == length(obs_idx)) {
+      ok <- !tab_has_key ||
+        identical(record_key(tab[[id_col]], tab[[idv_col]]), key_obs)
+      if(ok) vals <- tab[, cols, drop = FALSE]
+    }
+    if(is.null(vals) && tab_has_key) {
+      idx <- match(
+        key_obs_uniq,
+        disambiguate_key(record_key(tab[[id_col]], tab[[idv_col]]))
+      )
       ## Guard against tables that aren't from this run at all: require at
       ## least half of the observation records to be found.
       if(sum(!is.na(idx)) < length(idx) / 2) next
       vals <- tab[idx, cols, drop = FALSE]
-    } else {
-      next
     }
+    if(is.null(vals)) next
     for(col in cols) res_cols[[col]] <- unname(vals[[col]])
   }
   if(length(res_cols) == 0) return(NULL)
 
-  keys <- list(ROW = obs_idx)
+  ## Don't shadow a `ROW` column the dataset already carries: its values are
+  ## not row numbers once the dataset has been filtered (IGNORE=, ...), so a
+  ## join on it would silently mismatch.
+  row_col <- "ROW"
+  if(row_col %in% names(dataset)) {
+    row_col <- ".ROW"
+    cli::cli_warn(c(
+      "The dataset already has a {.field ROW} column, which does not necessarily hold row numbers.",
+      i = "The residuals row-number key is named {.field .ROW} instead."
+    ))
+  }
+
+  keys <- stats::setNames(list(obs_idx), row_col)
   if(id_col %in% names(dataset)) keys[[id_col]] <- dataset[[id_col]][obs_idx]
   if(idv_col %in% names(dataset)) keys[[idv_col]] <- dataset[[idv_col]][obs_idx]
   out <- as.data.frame(
@@ -94,6 +234,7 @@ build_keyed_residuals <- function(
     check.names = FALSE
   )
   rownames(out) <- NULL
+  attr(out, "row_col") <- row_col
   out
 }
 
@@ -118,30 +259,51 @@ build_keyed_residuals <- function(
 #' (e.g. `plot_cwres_vs_idv()`) and code that assumes the non-observations
 #' have been filtered (e.g. `ruvsearch`) keep working.
 #'
-#' Leaves the fit untouched when no residual column can be found in the
-#' tables, or when the Pharmpy object cannot be rebuilt.
+#' Warns and leaves the fit untouched when no residual column can be found in
+#' the tables, or when the Pharmpy object cannot be rebuilt.
 #'
 #' @param fit Fit object: either a Pharmpy `ModelfitResults` object or an
 #'   nlmixr2-shaped fit list.
 #' @param model Pharmpy model object the fit belongs to.
 #' @param tables Named list of output tables, from [get_tables_from_fit()].
+#' @param dataset Dataset the model was actually fitted to. Defaults to
+#'   `model$dataset`; the nlmixr2 path passes the resolved fit data, which can
+#'   differ (an explicit `data =` argument, or `attr(model, "original_data")`).
 #' @param verbose Verbose output?
 #'
 #' @noRd
-repair_residuals <- function(fit, model, tables, verbose = FALSE) {
+repair_residuals <- function(
+  fit,
+  model,
+  tables,
+  dataset = NULL,
+  verbose = FALSE
+) {
   if(is.null(fit) || is.null(model)) return(fit)
-  dataset <- tryCatch(model$dataset, error = function(e) NULL)
+  if(is.null(dataset)) {
+    dataset <- tryCatch(model$dataset, error = function(e) NULL)
+  }
+  if(!is.null(dataset) && !is.data.frame(dataset)) {
+    dataset <- tryCatch(as.data.frame(dataset), error = function(e) NULL)
+  }
   key_cols <- dataset_key_columns(model)
   res <- tryCatch(
     build_keyed_residuals(
       dataset,
       tables,
       id_col = key_cols$id,
-      idv_col = key_cols$idv
+      idv_col = key_cols$idv,
+      verbose = verbose
     ),
     error = function(e) NULL
   )
   if(is.null(res) || nrow(res) == 0) {
+    if(fit_has_residuals(fit)) {
+      cli::cli_warn(c(
+        "Could not rebuild a joinable {.field residuals} frame from the output tables.",
+        i = "{.code fit$residuals} is left as returned by the fitting engine: it carries no join key and may not align with the observation records."
+      ))
+    }
     return(fit)
   }
 
@@ -149,23 +311,54 @@ repair_residuals <- function(fit, model, tables, verbose = FALSE) {
     new_fit <- tryCatch(
       set_pharmpy_residuals(fit, model, res),
       error = function(e) {
-        if(verbose) {
-          cli::cli_alert_warning(
-            "Could not update `residuals` on fit object: {conditionMessage(e)}"
-          )
-        }
+        cli::cli_warn(c(
+          "Could not update {.field residuals} on the fit object: {conditionMessage(e)}",
+          i = "{.code fit$residuals} is left as returned by Pharmpy."
+        ))
         NULL
       }
     )
-    if(!is.null(new_fit)) fit <- new_fit
+    if(!is.null(new_fit)) {
+      ## `dataclasses.replace()` returns a new object, so carry over any
+      ## attributes a caller had already attached to the old one.
+      fit <- copy_fit_attributes(from = fit, to = new_fit)
+    }
   } else if(is.list(fit) &&
             (inherits(fit, "nlmixr2_modelfit_results") ||
              "residuals" %in% names(fit))) {
     ## Only fit-shaped lists: an evaluation-only run returns an empty list,
     ## which should stay empty.
+    attr(res, "row_col") <- NULL
     fit$residuals <- res
   }
   fit
+}
+
+#' Does a fit carry a non-empty `residuals` slot?
+#'
+#' Used to decide whether a failed repair is worth warning about: there is
+#' nothing to warn about when the fit never had residuals (e.g. an
+#' evaluation-only run).
+#'
+#' @noRd
+fit_has_residuals <- function(fit) {
+  res <- tryCatch(fit$residuals, error = function(e) NULL)
+  if(is.null(res)) return(FALSE)
+  if(is.data.frame(res)) return(nrow(res) > 0)
+  TRUE
+}
+
+#' Copy user attributes from one fit object onto another
+#'
+#' @noRd
+copy_fit_attributes <- function(from, to) {
+  attrs <- attributes(from)
+  attrs <- attrs[setdiff(
+    names(attrs),
+    c("class", "names", "row.names", "dim", "dimnames")
+  )]
+  for(nm in names(attrs)) attr(to, nm) <- attrs[[nm]]
+  to
 }
 
 #' Get the ID and independent-variable column names of a model
@@ -187,18 +380,24 @@ dataset_key_columns <- function(model) {
 #'
 #' `ModelfitResults` is a frozen dataclass, so the slot is replaced with
 #' `dataclasses.replace()`. The pandas index of the new frame is set to the
-#' `model.dataset` row labels of the observation records (taken from the `ROW`
-#' column), which is what Pharmpy itself uses as join key.
+#' `model.dataset` row labels of the observation records (taken from the row
+#' number column), which is what Pharmpy itself uses as join key. When that
+#' index cannot be established the helper raises rather than falling back to a
+#' default `RangeIndex`: Pharmpy consumers do `model.dataset.loc[res.index]`,
+#' which would then silently select the first `n` dataset rows.
 #'
 #' @noRd
 set_pharmpy_residuals <- function(fit, model, residuals) {
   .define_residuals_helper()
+  row_col <- attr(residuals, "row_col") %||% "ROW"
+  rows <- residuals[[row_col]]
+  attr(residuals, "row_col") <- NULL
   py_main <- reticulate::import_main()
   py_main$`_pharmr_extra_set_residuals`(
     fit,
     model,
     residuals,
-    as.integer(residuals$ROW)
+    as.integer(rows)
   )
 }
 
@@ -224,13 +423,18 @@ def _pharmr_extra_set_residuals(results, model, residuals, positions):
     df = df.copy()
     # Index by dataset row label, like pharmpy's own _parse_tables() does, so
     # that `dataset.loc[residuals.index]` still works on the returned object.
-    try:
-        dataset = model.dataset
-        rows = [int(p) - 1 for p in positions]
-        if dataset is not None and len(rows) > 0 and max(rows) < len(dataset):
-            df.index = dataset.index[rows]
-    except Exception:
-        pass
+    # Raise rather than leaving a default RangeIndex in place: pharmpy joins
+    # with `model.dataset.loc[residuals.index]`, which would silently select
+    # the first len(df) dataset rows (dose records included).
+    dataset = model.dataset
+    if dataset is None:
+        raise ValueError('model has no dataset; cannot index residuals')
+    rows = [int(p) - 1 for p in positions]
+    if len(rows) == 0:
+        raise ValueError('no observation rows to index residuals by')
+    if min(rows) < 0 or max(rows) >= len(dataset):
+        raise ValueError('residual row numbers fall outside the model dataset')
+    df.index = dataset.index[rows]
     return _dataclasses.replace(results, residuals=df)
 ")
 

--- a/R/repair_residuals.R
+++ b/R/repair_residuals.R
@@ -1,0 +1,239 @@
+#' Residual column names recognized in NONMEM / nlmixr2 output tables
+#'
+#' Superset of the columns Pharmpy looks at (`RES`, `WRES`, `CWRES`), since
+#' `add_default_output_tables()` writes `CWRES`, `CIWRES` and `NPDE`, and
+#' nlmixr2 fits report `IRES`/`IWRES`/`CWRES`.
+#'
+#' @noRd
+residual_column_names <- function() {
+  c(
+    "RES", "IRES", "WRES", "IWRES", "CRES", "CWRES", "CIWRES",
+    "CWRESI", "IWRESI", "EWRES", "ECWRES", "NPDE", "NPD"
+  )
+}
+
+#' Build a joinable residuals frame from a fit's output tables
+#'
+#' Returns one row per observation record of `dataset`, with the row number in
+#' `dataset` (`ROW`), the ID and independent-variable columns as join keys, and
+#' every residual column found in `tables`.
+#'
+#' Tables are matched against the dataset in three ways, in order:
+#'   1. one row per dataset record (the NONMEM `$TABLE` convention) — the
+#'      observation rows are subset out;
+#'   2. one row per observation record (the `as.data.frame(nlmixr2fit)`
+#'      convention) — used as-is;
+#'   3. otherwise, aligned on the ID/IDV key (NA where a record has no
+#'      matching table row). Only the first match is used per key, so this
+#'      degrades to NA rather than guessing when keys are duplicated, and the
+#'      table is ignored altogether when fewer than half the observation
+#'      records are found (i.e. it isn't from this run).
+#'
+#' Returns `NULL` when no residual column can be located, so callers can leave
+#' the fit untouched.
+#'
+#' @param dataset Model dataset as a data.frame (i.e. `model$dataset`).
+#' @param tables Named list of output tables, as attached by
+#'   [get_tables_from_fit()].
+#' @param id_col Name of the ID column in `dataset` and the tables.
+#' @param idv_col Name of the independent variable (time) column.
+#'
+#' @noRd
+build_keyed_residuals <- function(
+  dataset,
+  tables,
+  id_col = "ID",
+  idv_col = "TIME"
+) {
+  if(is.null(dataset) || !is.data.frame(dataset) || nrow(dataset) == 0) {
+    return(NULL)
+  }
+  if(is.null(tables) || length(tables) == 0) {
+    return(NULL)
+  }
+  obs_idx <- find_observation_rows(dataset)
+  if(is.null(obs_idx)) obs_idx <- seq_len(nrow(dataset))
+  if(length(obs_idx) == 0) return(NULL)
+
+  has_key <- all(c(id_col, idv_col) %in% names(dataset))
+  if(has_key) {
+    key_obs <- paste(dataset[[id_col]][obs_idx], dataset[[idv_col]][obs_idx])
+  }
+
+  res_cols <- list()
+  for(tab in tables) {
+    if(!is.data.frame(tab) || nrow(tab) == 0) next
+    cols <- setdiff(
+      intersect(residual_column_names(), names(tab)),
+      names(res_cols)
+    )
+    if(length(cols) == 0) next
+    if(nrow(tab) == nrow(dataset)) {
+      vals <- tab[obs_idx, cols, drop = FALSE]
+    } else if(nrow(tab) == length(obs_idx)) {
+      vals <- tab[, cols, drop = FALSE]
+    } else if(has_key && all(c(id_col, idv_col) %in% names(tab))) {
+      idx <- match(key_obs, paste(tab[[id_col]], tab[[idv_col]]))
+      ## Guard against tables that aren't from this run at all: require at
+      ## least half of the observation records to be found.
+      if(sum(!is.na(idx)) < length(idx) / 2) next
+      vals <- tab[idx, cols, drop = FALSE]
+    } else {
+      next
+    }
+    for(col in cols) res_cols[[col]] <- unname(vals[[col]])
+  }
+  if(length(res_cols) == 0) return(NULL)
+
+  keys <- list(ROW = obs_idx)
+  if(id_col %in% names(dataset)) keys[[id_col]] <- dataset[[id_col]][obs_idx]
+  if(idv_col %in% names(dataset)) keys[[idv_col]] <- dataset[[idv_col]][obs_idx]
+  out <- as.data.frame(
+    c(keys, res_cols),
+    stringsAsFactors = FALSE,
+    check.names = FALSE
+  )
+  rownames(out) <- NULL
+  out
+}
+
+#' Replace the `residuals` slot on a fit with a joinable version
+#'
+#' Pharmpy's NONMEM parser exposes `residuals` as a DataFrame indexed by
+#' dataset row label, with rows removed by a `(df != 0).any(axis=1)` heuristic
+#' (`_parse_residuals()`). That breaks R callers twice over:
+#'
+#'   * reticulate drops the pandas index on conversion, so the only join key
+#'     is gone and `fit$residuals` cannot be attached to the dataset;
+#'   * the heuristic also drops *observation* records whose residual columns
+#'     are all exactly 0 (NONMEM writes 0 for records it did not compute a
+#'     residual for), so the row count doesn't match the observation records
+#'     either — `nrow(fit$residuals)` was 1134 for a 2184-observation dataset
+#'     (#120).
+#'
+#' This rebuilds the slot from the run's output tables: one row per
+#' observation record, with `ROW`/ID/IDV keys (see [build_keyed_residuals()]).
+#' For NONMEM fits the pandas index is set to the corresponding
+#' `model.dataset` labels, so Pharmpy code that joins on `residuals.index`
+#' (e.g. `plot_cwres_vs_idv()`) and code that assumes the non-observations
+#' have been filtered (e.g. `ruvsearch`) keep working.
+#'
+#' Leaves the fit untouched when no residual column can be found in the
+#' tables, or when the Pharmpy object cannot be rebuilt.
+#'
+#' @param fit Fit object: either a Pharmpy `ModelfitResults` object or an
+#'   nlmixr2-shaped fit list.
+#' @param model Pharmpy model object the fit belongs to.
+#' @param tables Named list of output tables, from [get_tables_from_fit()].
+#' @param verbose Verbose output?
+#'
+#' @noRd
+repair_residuals <- function(fit, model, tables, verbose = FALSE) {
+  if(is.null(fit) || is.null(model)) return(fit)
+  dataset <- tryCatch(model$dataset, error = function(e) NULL)
+  key_cols <- dataset_key_columns(model)
+  res <- tryCatch(
+    build_keyed_residuals(
+      dataset,
+      tables,
+      id_col = key_cols$id,
+      idv_col = key_cols$idv
+    ),
+    error = function(e) NULL
+  )
+  if(is.null(res) || nrow(res) == 0) {
+    return(fit)
+  }
+
+  if(inherits(fit, "python.builtin.object")) {
+    new_fit <- tryCatch(
+      set_pharmpy_residuals(fit, model, res),
+      error = function(e) {
+        if(verbose) {
+          cli::cli_alert_warning(
+            "Could not update `residuals` on fit object: {conditionMessage(e)}"
+          )
+        }
+        NULL
+      }
+    )
+    if(!is.null(new_fit)) fit <- new_fit
+  } else if(is.list(fit) &&
+            (inherits(fit, "nlmixr2_modelfit_results") ||
+             "residuals" %in% names(fit))) {
+    ## Only fit-shaped lists: an evaluation-only run returns an empty list,
+    ## which should stay empty.
+    fit$residuals <- res
+  }
+  fit
+}
+
+#' Get the ID and independent-variable column names of a model
+#'
+#' Falls back to the NONMEM defaults `ID` / `TIME` when the datainfo cannot be
+#' read (e.g. a fit object without a usable model attached).
+#'
+#' @noRd
+dataset_key_columns <- function(model) {
+  id <- tryCatch(model$datainfo$id_column$name, error = function(e) NULL)
+  idv <- tryCatch(model$datainfo$idv_column$name, error = function(e) NULL)
+  list(
+    id = if(is.null(id) || !is.character(id)) "ID" else id,
+    idv = if(is.null(idv) || !is.character(idv)) "TIME" else idv
+  )
+}
+
+#' Return a copy of a Pharmpy ModelfitResults with new `residuals`
+#'
+#' `ModelfitResults` is a frozen dataclass, so the slot is replaced with
+#' `dataclasses.replace()`. The pandas index of the new frame is set to the
+#' `model.dataset` row labels of the observation records (taken from the `ROW`
+#' column), which is what Pharmpy itself uses as join key.
+#'
+#' @noRd
+set_pharmpy_residuals <- function(fit, model, residuals) {
+  .define_residuals_helper()
+  py_main <- reticulate::import_main()
+  py_main$`_pharmr_extra_set_residuals`(
+    fit,
+    model,
+    residuals,
+    as.integer(residuals$ROW)
+  )
+}
+
+# R-level flag to avoid re-defining the Python helper in every call.
+.residuals_helper_defined <- local({
+  defined <- FALSE
+  list(
+    get = function() defined,
+    set = function() defined <<- TRUE
+  )
+})
+
+# Define the Python helper that rebuilds the ModelfitResults (idempotent).
+.define_residuals_helper <- function() {
+  if(.residuals_helper_defined$get()) return(invisible(NULL))
+
+  reticulate::py_run_string("
+import dataclasses as _dataclasses
+from pharmpy.deps import pandas as _pd
+
+def _pharmr_extra_set_residuals(results, model, residuals, positions):
+    df = residuals if isinstance(residuals, _pd.DataFrame) else _pd.DataFrame(residuals)
+    df = df.copy()
+    # Index by dataset row label, like pharmpy's own _parse_tables() does, so
+    # that `dataset.loc[residuals.index]` still works on the returned object.
+    try:
+        dataset = model.dataset
+        rows = [int(p) - 1 for p in positions]
+        if dataset is not None and len(rows) > 0 and max(rows) < len(dataset):
+            df.index = dataset.index[rows]
+    except Exception:
+        pass
+    return _dataclasses.replace(results, residuals=df)
+")
+
+  .residuals_helper_defined$set()
+  invisible(NULL)
+}

--- a/R/run_nlme.R
+++ b/R/run_nlme.R
@@ -107,7 +107,12 @@
 #' [nlmixr2est::saemControl()]). Ignored for NONMEM models.
 #' @param verbose verbose output?
 #'
-#' @returns TODO
+#' @returns A Pharmpy `ModelfitResults` object (an nlmixr2-shaped fit list for
+#'   nlmixr2 models), with the model, the output tables and a fit summary
+#'   attached as the `model`, `tables` and `info` attributes. `predictions`
+#'   holds one row per record of the model dataset, `residuals` one row per
+#'   observation record plus `ROW` (row number in `model$dataset`), `ID` and
+#'   `TIME` columns to join on.
 #'
 #' @export
 run_nlme <- function(

--- a/R/run_nlme.R
+++ b/R/run_nlme.R
@@ -110,9 +110,13 @@
 #' @returns A Pharmpy `ModelfitResults` object (an nlmixr2-shaped fit list for
 #'   nlmixr2 models), with the model, the output tables and a fit summary
 #'   attached as the `model`, `tables` and `info` attributes. `predictions`
-#'   holds one row per record of the model dataset, `residuals` one row per
-#'   observation record plus `ROW` (row number in `model$dataset`), `ID` and
-#'   `TIME` columns to join on.
+#'   holds one row per record of the model dataset; `residuals` holds one row
+#'   per observation record, plus join keys: `ROW` (row number in the model
+#'   dataset) and the model's ID and independent-variable columns. The latter
+#'   two are taken from the model's datainfo, so they are named `ID` and `TIME`
+#'   for a typical NONMEM dataset but follow the dataset when it uses other
+#'   names (e.g. `SUBJ` / `TAD`). `ROW` is named `.ROW` in the rare case that
+#'   the dataset already has a column called `ROW`.
 #'
 #' @export
 run_nlme <- function(

--- a/R/run_nlme_nlmixr.R
+++ b/R/run_nlme_nlmixr.R
@@ -376,7 +376,9 @@ as_pharmpy_shaped_fit <- function(raw_fit, model, input_data = NULL) {
   ## Match pharmpy's row-shape convention: `predictions` keeps all rows from
   ## the input dataset (NA for non-observation events), so that
   ## `bind_cols(model$dataset, fit$predictions)` works. `residuals` is
-  ## observation-only (pharmpy filters non-obs out — see `_parse_residuals`).
+  ## observation-only (pharmpy filters non-obs out — see `_parse_residuals`);
+  ## `attach_fit_info_nlmixr()` then adds the ROW/ID/TIME join keys via
+  ## `repair_residuals()`, matching the NONMEM path.
   fit_df <- tryCatch(as.data.frame(raw_fit), error = function(e) NULL)
   pred_cols <- c("PRED", "IPRED", "CPRED", "CIPREDI", "EPRED")
   res_cols  <- c("RES", "IRES", "WRES", "IWRES", "CWRES", "CWRESI")
@@ -433,7 +435,12 @@ attach_fit_info_nlmixr <- function(fit, model, raw_fit, fit_folder) {
   if("ID" %in% names(fit_df) && is.factor(fit_df$ID)) {
     fit_df$ID <- as.numeric(as.character(fit_df$ID))
   }
-  attr(fit, "tables") <- list(sdtab = fit_df)
+  tables <- list(sdtab = fit_df)
+  attr(fit, "tables") <- tables
+
+  ## Give `residuals` the same observation-aligned, keyed shape as the NONMEM
+  ## path (ROW / ID / TIME + residual columns), so GoF code is engine-agnostic.
+  fit <- repair_residuals(fit, model, tables)
 
   attr(fit, "info") <- get_fit_info_nlmixr(fit)
   fit

--- a/R/run_nlme_nlmixr.R
+++ b/R/run_nlme_nlmixr.R
@@ -158,7 +158,9 @@ run_nlme_nlmixr <- function(
     fit = fit,
     model = model,
     raw_fit = raw_fit,
-    fit_folder = fit_folder
+    fit_folder = fit_folder,
+    data = fit_data,
+    verbose = verbose
   )
 
   ## Build & store a "final" pharmpy model with updated estimates so that
@@ -424,8 +426,20 @@ as_pharmpy_shaped_fit <- function(raw_fit, model, input_data = NULL) {
 #' named `sdtab` so example code that reads `attr(fit, "tables")$sdtab`
 #' continues to work.
 #'
+#' @param data Dataset the model was actually fitted to (the output of
+#'   [resolve_nlmixr_data()]). Required to key the residuals: `model$dataset`
+#'   still points at whatever was attached at model-build time, which is not
+#'   the fit data when the caller supplied an explicit `data =` argument.
+#'
 #' @noRd
-attach_fit_info_nlmixr <- function(fit, model, raw_fit, fit_folder) {
+attach_fit_info_nlmixr <- function(
+  fit,
+  model,
+  raw_fit,
+  fit_folder,
+  data = NULL,
+  verbose = FALSE
+) {
   attr(fit, "model") <- model
 
   ## Build sdtab-equivalent from the fit data.frame.
@@ -440,7 +454,16 @@ attach_fit_info_nlmixr <- function(fit, model, raw_fit, fit_folder) {
 
   ## Give `residuals` the same observation-aligned, keyed shape as the NONMEM
   ## path (ROW / ID / TIME + residual columns), so GoF code is engine-agnostic.
-  fit <- repair_residuals(fit, model, tables)
+  ## Keyed against the data actually fitted — the same frame `predictions` was
+  ## expanded against — not `model$dataset`, which can be a different dataset.
+  fit <- repair_residuals(
+    fit,
+    model,
+    tables,
+    dataset = data %||%
+      tryCatch(resolve_nlmixr_data(model, NULL), error = function(e) NULL),
+    verbose = verbose
+  )
 
   attr(fit, "info") <- get_fit_info_nlmixr(fit)
   fit

--- a/man/attach_fit_info.Rd
+++ b/man/attach_fit_info.Rd
@@ -20,16 +20,27 @@ attach_fit_info(
 \item{model}{pharmpy model object or NONMEM model code (character) or path
 to NONMEM model file.}
 
-\item{fit_folder}{TODO}
+\item{fit_folder}{Folder the run was executed in, holding the output
+tables and the estimation output file.}
 
 \item{output_file}{NONMEM output file, default is \code{run.lst}}
 
-\item{is_sim_model}{TODO}
+\item{is_sim_model}{Is \code{fit} the result of a simulation rather than an
+estimation? Simulation results have no fit summary and no residuals to
+repair.}
 
 \item{verbose}{verbose output?}
 }
 \value{
-TODO
+The fit object with the model, the output tables and (for
+estimation runs) a fit summary attached as the \code{model}, \code{tables} and
+\code{info} attributes, and with \code{residuals} rebuilt into a joinable frame
+(see the \code{Value} section of \code{\link[=run_nlme]{run_nlme()}}).
+
+Note that for a Pharmpy fit this is a \emph{new} object — \code{ModelfitResults} is
+a frozen dataclass, so replacing \code{residuals} means replacing the object.
+Attributes already set on the fit passed in are carried over, but any
+reference the caller still holds points at the un-repaired fit.
 }
 \description{
 Attach fit info and tables to a fit object, e.g. from model fit or

--- a/man/run_nlme.Rd
+++ b/man/run_nlme.Rd
@@ -161,9 +161,13 @@ pharmpy's API does not expose a parafile hook.}
 A Pharmpy \code{ModelfitResults} object (an nlmixr2-shaped fit list for
 nlmixr2 models), with the model, the output tables and a fit summary
 attached as the \code{model}, \code{tables} and \code{info} attributes. \code{predictions}
-holds one row per record of the model dataset, \code{residuals} one row per
-observation record plus \code{ROW} (row number in \code{model$dataset}), \code{ID} and
-\code{TIME} columns to join on.
+holds one row per record of the model dataset; \code{residuals} holds one row
+per observation record, plus join keys: \code{ROW} (row number in the model
+dataset) and the model's ID and independent-variable columns. The latter
+two are taken from the model's datainfo, so they are named \code{ID} and \code{TIME}
+for a typical NONMEM dataset but follow the dataset when it uses other
+names (e.g. \code{SUBJ} / \code{TAD}). \code{ROW} is named \code{.ROW} in the rare case that
+the dataset already has a column called \code{ROW}.
 }
 \description{
 Run the model directly using nmfe (not through pharmpy).

--- a/man/run_nlme.Rd
+++ b/man/run_nlme.Rd
@@ -158,7 +158,12 @@ pharmpy's API does not expose a parafile hook.}
 \item{verbose}{verbose output?}
 }
 \value{
-TODO
+A Pharmpy \code{ModelfitResults} object (an nlmixr2-shaped fit list for
+nlmixr2 models), with the model, the output tables and a fit summary
+attached as the \code{model}, \code{tables} and \code{info} attributes. \code{predictions}
+holds one row per record of the model dataset, \code{residuals} one row per
+observation record plus \code{ROW} (row number in \code{model$dataset}), \code{ID} and
+\code{TIME} columns to join on.
 }
 \description{
 Run the model directly using nmfe (not through pharmpy).

--- a/tests/testthat/test-attach_fit_info.R
+++ b/tests/testthat/test-attach_fit_info.R
@@ -3,8 +3,15 @@ test_that("attaches model, tables, and fit info to fit object", {
   mod <- pharmr::load_example_model("pheno")
   fit <- pharmr::load_example_modelfit_results("pheno")
   run_folder <- test_path("fixtures", "run_folder")
-  out <- attach_fit_info(fit = fit, model = mod, fit_folder = run_folder)
-  
+  ## The fixture run folder is from a different model than `pheno`, so the
+  ## tables cannot be aligned with the dataset and residual repair warns and
+  ## no-ops. That is the point of the warning; this test only checks that the
+  ## attributes are attached.
+  expect_warning(
+    out <- attach_fit_info(fit = fit, model = mod, fit_folder = run_folder),
+    "Could not rebuild"
+  )
+
   # fit object data is preserved:
   expect_equal(out$ofv, fit$ofv)
   expect_equal(out$parameter_estimates, fit$parameter_estimates)

--- a/tests/testthat/test-repair_residuals.R
+++ b/tests/testthat/test-repair_residuals.R
@@ -366,14 +366,19 @@ test_that("set_pharmpy_residuals replaces the slot on a Pharmpy fit", {
   expect_equal(out$parameter_estimates, fit$parameter_estimates)
   # the pandas index is set to the dataset row labels, which is what pharmpy
   # itself joins on:
-  py_res <- reticulate::py_get_attr(out, "residuals")
   ## reticulate has no converter for a pandas Index — py_to_r() would hand
-  ## back the Python object untouched — so read it out as a list.
-  py_index <- reticulate::py_get_attr(py_res, "index")$tolist()
-  if(inherits(py_index, "python.builtin.object")) {
-    py_index <- reticulate::py_to_r(py_index)
+  ## back the Python object untouched — so read it out as a list. The
+  ## expectation is derived from the dataset rather than assuming the index
+  ## runs 0..n-1: what matters is that the labels are the ones the dataset
+  ## carries at those row positions, whatever they are numbered from.
+  py_index_of <- function(x) {
+    idx <- reticulate::py_get_attr(x, "index")$tolist()
+    if(inherits(idx, "python.builtin.object")) idx <- reticulate::py_to_r(idx)
+    as.numeric(unlist(idx))
   }
-  expect_equal(as.numeric(unlist(py_index)), rows - 1)
+  py_res <- reticulate::py_get_attr(out, "residuals")
+  dataset_labels <- py_index_of(reticulate::py_get_attr(model, "dataset"))
+  expect_equal(py_index_of(py_res), dataset_labels[rows])
 })
 
 test_that("set_pharmpy_residuals refuses to fall back to a default index", {

--- a/tests/testthat/test-repair_residuals.R
+++ b/tests/testthat/test-repair_residuals.R
@@ -367,8 +367,13 @@ test_that("set_pharmpy_residuals replaces the slot on a Pharmpy fit", {
   # the pandas index is set to the dataset row labels, which is what pharmpy
   # itself joins on:
   py_res <- reticulate::py_get_attr(out, "residuals")
-  py_index <- reticulate::py_to_r(reticulate::py_get_attr(py_res, "index"))
-  expect_equal(as.numeric(py_index), rows - 1)
+  ## reticulate has no converter for a pandas Index — py_to_r() would hand
+  ## back the Python object untouched — so read it out as a list.
+  py_index <- reticulate::py_get_attr(py_res, "index")$tolist()
+  if(inherits(py_index, "python.builtin.object")) {
+    py_index <- reticulate::py_to_r(py_index)
+  }
+  expect_equal(as.numeric(unlist(py_index)), rows - 1)
 })
 
 test_that("set_pharmpy_residuals refuses to fall back to a default index", {

--- a/tests/testthat/test-repair_residuals.R
+++ b/tests/testthat/test-repair_residuals.R
@@ -64,6 +64,120 @@ test_that("build_keyed_residuals accepts observation-only tables", {
   expect_equal(res$IWRES, c(0.1, -0.2, 0.3, -0.4))
 })
 
+test_that("build_keyed_residuals checks the key before binding positionally", {
+  # as.data.frame(nlmixr2fit) returns rows in nlmixr2's ID-sorted order, which
+  # need not be the dataset order.
+  local_pharmr.extra_options()
+  dataset <- make_residual_test_dataset()
+  dataset <- dataset[c(4, 5, 6, 1, 2, 3), ]  # subject 2 first
+  rownames(dataset) <- NULL
+  obs_table <- data.frame(  # still in ID order 1, 1, 2, 2
+    ID = c(1, 1, 2, 2),
+    TIME = c(1, 2, 1, 2),
+    IWRES = c(0.1, -0.2, 0.3, -0.4)
+  )
+
+  res <- build_keyed_residuals(dataset, list(sdtab = obs_table))
+
+  # Fell through to key alignment rather than binding row-for-row.
+  expect_equal(res$ID, c(2, 2, 1, 1))
+  expect_equal(res$IWRES, c(0.3, -0.4, 0.1, -0.2))
+})
+
+test_that("build_keyed_residuals uses the last block of a stacked table", {
+  # read_table_nm() skips only the first `TABLE NO.` header, so a multi-step
+  # estimation (SAEM then IMP) comes back as several stacked copies.
+  local_pharmr.extra_options()
+  dataset <- make_residual_test_dataset()
+  saem <- data.frame(
+    ID = dataset$ID, TIME = dataset$TIME,
+    CWRES = c(0, 9, 9, 0, 9, 9)
+  )
+  imp <- data.frame(
+    ID = dataset$ID, TIME = dataset$TIME,
+    CWRES = c(0, 0.5, -0.3, 0, 1.1, -0.9)
+  )
+
+  res <- build_keyed_residuals(dataset, list(sdtab = rbind(saem, imp)))
+
+  expect_equal(nrow(res), 4)
+  expect_equal(res$CWRES, c(0.5, -0.3, 1.1, -0.9))
+})
+
+test_that("build_keyed_residuals matches keys at NONMEM table precision", {
+  # NONMEM writes tables at ~5 significant digits, so a dataset TIME of
+  # 0.0833333 comes back as 8.33330E-02.
+  local_pharmr.extra_options()
+  dataset <- data.frame(
+    ID = c(1, 1, 1),
+    TIME = c(0, 0.0833333, 1.0166667),
+    MDV = c(1, 0, 0)
+  )
+  tab <- data.frame(
+    ID = c(1, 1),
+    TIME = c(0.083333, 1.01667),
+    CWRES = c(0.5, -0.3)
+  )
+
+  res <- build_keyed_residuals(dataset, list(sdtab = tab))
+
+  expect_equal(res$CWRES, c(0.5, -0.3))
+})
+
+test_that("build_keyed_residuals matches character IDs against numeric IDs", {
+  local_pharmr.extra_options()
+  dataset <- data.frame(
+    ID = c("001", "001", "002"),
+    TIME = c(0, 1, 1),
+    MDV = c(1, 0, 0),
+    stringsAsFactors = FALSE
+  )
+  tab <- data.frame(ID = c(1, 2), TIME = c(1, 1), CWRES = c(0.5, -0.3))
+
+  res <- build_keyed_residuals(dataset, list(sdtab = tab))
+
+  expect_equal(res$CWRES, c(0.5, -0.3))
+})
+
+test_that("build_keyed_residuals pairs repeated ID/TIME keys in order", {
+  # Two analytes measured at the same nominal time: the key is duplicated, so
+  # occurrences are paired up rather than all collapsing onto the first hit.
+  local_pharmr.extra_options()
+  dataset <- data.frame(
+    ID = c(1, 1, 1, 2),
+    TIME = c(0, 1, 1, 0),
+    MDV = c(1, 0, 0, 1)
+  )
+  # Neither length branch applies, so this goes through key alignment.
+  tab <- data.frame(
+    ID = c(1, 1, 2),
+    TIME = c(1, 1, 5),
+    CWRES = c(0.5, -0.3, 9)
+  )
+
+  res <- build_keyed_residuals(dataset, list(sdtab = tab))
+
+  expect_equal(res$CWRES, c(0.5, -0.3))
+})
+
+test_that("build_keyed_residuals does not shadow an existing ROW column", {
+  local_pharmr.extra_options()
+  dataset <- make_residual_test_dataset()
+  dataset$ROW <- c(11, 12, 13, 14, 15, 16)  # not row numbers
+  tab <- data.frame(
+    ID = dataset$ID, TIME = dataset$TIME,
+    CWRES = c(0, 0.5, -0.3, 0, 1.1, -0.9)
+  )
+
+  expect_warning(
+    res <- build_keyed_residuals(dataset, list(sdtab = tab)),
+    "already has a"
+  )
+  expect_equal(names(res), c(".ROW", "ID", "TIME", "CWRES"))
+  expect_equal(res$.ROW, c(2, 3, 5, 6))
+  expect_equal(attr(res, "row_col"), ".ROW")
+})
+
 test_that("build_keyed_residuals aligns on ID/TIME when row counts don't match", {
   local_pharmr.extra_options()
   dataset <- make_residual_test_dataset()
@@ -172,14 +286,56 @@ test_that("repair_residuals replaces the slot on an nlmixr2-shaped fit", {
   expect_equal(out$ofv, 1)
 })
 
-test_that("repair_residuals leaves the fit untouched when tables are unusable", {
+test_that("repair_residuals keys against an explicit dataset when given", {
+  # The nlmixr2 path fits `resolve_nlmixr_data(model, data)`, which is not
+  # `model$dataset` when the caller passed an explicit `data =`.
+  local_pharmr.extra_options()
+  model <- list(dataset = make_residual_test_dataset())
+  fit_data <- data.frame(
+    ID = c(3, 3, 3),
+    TIME = c(0, 1, 2),
+    MDV = c(1, 0, 0),
+    DV = c(0, 5, 6)
+  )
+  fit <- structure(
+    list(residuals = data.frame(CWRES = c(1, 2))),
+    class = c("nlmixr2_modelfit_results", "list")
+  )
+  tables <- list(
+    sdtab = data.frame(ID = c(3, 3), TIME = c(1, 2), CWRES = c(0.7, -0.6))
+  )
+
+  out <- repair_residuals(fit, model, tables, dataset = fit_data)
+
+  expect_equal(out$residuals$ID, c(3, 3))
+  expect_equal(out$residuals$ROW, c(2, 3))
+  expect_equal(out$residuals$CWRES, c(0.7, -0.6))
+})
+
+test_that("repair_residuals warns and leaves the fit untouched when tables are unusable", {
   local_pharmr.extra_options()
   model <- list(dataset = make_residual_test_dataset())
   fit <- list(residuals = data.frame(CWRES = 1))
 
-  expect_equal(repair_residuals(fit, model, list()), fit)
+  expect_warning(
+    expect_equal(repair_residuals(fit, model, list()), fit),
+    "Could not rebuild"
+  )
   expect_equal(repair_residuals(fit, NULL, list()), fit)
   expect_null(repair_residuals(NULL, model, list()))
+})
+
+test_that("repair_residuals stays silent when there were no residuals to fix", {
+  # e.g. an evaluation-only run.
+  local_pharmr.extra_options()
+  model <- list(dataset = make_residual_test_dataset())
+
+  expect_no_warning(out <- repair_residuals(list(), model, list()))
+  expect_equal(out, list())
+  expect_no_warning(
+    out2 <- repair_residuals(list(residuals = data.frame()), model, list())
+  )
+  expect_equal(out2, list(residuals = data.frame()))
 })
 
 test_that("set_pharmpy_residuals replaces the slot on a Pharmpy fit", {
@@ -213,6 +369,39 @@ test_that("set_pharmpy_residuals replaces the slot on a Pharmpy fit", {
   py_res <- reticulate::py_get_attr(out, "residuals")
   py_index <- reticulate::py_to_r(reticulate::py_get_attr(py_res, "index"))
   expect_equal(as.numeric(py_index), rows - 1)
+})
+
+test_that("set_pharmpy_residuals refuses to fall back to a default index", {
+  # A RangeIndex would make pharmpy's `dataset.loc[residuals.index]` silently
+  # select the first n dataset rows, dose records included.
+  local_pharmr.extra_options()
+  skip_if_not(
+    reticulate::py_module_available("pharmpy"),
+    "Pharmpy not available"
+  )
+  model <- pharmr::load_example_model("pheno")
+  fit <- pharmr::load_example_modelfit_results("pheno")
+  res <- data.frame(
+    ROW = c(1, nrow(model$dataset) + 10),
+    ID = c(1, 1),
+    TIME = c(0, 1),
+    CWRES = c(0.1, -0.2)
+  )
+
+  expect_error(set_pharmpy_residuals(fit, model, res), "outside the model dataset")
+})
+
+test_that("copy_fit_attributes carries user attributes onto the new object", {
+  local_pharmr.extra_options()
+  from <- structure(list(a = 1), class = "old_class", run = "run1", info = 2)
+  to <- structure(list(b = 2), class = "new_class")
+
+  out <- copy_fit_attributes(from, to)
+
+  expect_equal(attr(out, "run"), "run1")
+  expect_equal(attr(out, "info"), 2)
+  expect_s3_class(out, "new_class")  # class is not overwritten
+  expect_equal(names(out), "b")
 })
 
 test_that("dataset_key_columns falls back to ID/TIME", {

--- a/tests/testthat/test-repair_residuals.R
+++ b/tests/testthat/test-repair_residuals.R
@@ -1,0 +1,230 @@
+make_residual_test_dataset <- function() {
+  data.frame(
+    ID = c(1, 1, 1, 2, 2, 2),
+    TIME = c(0, 1, 2, 0, 1, 2),
+    EVID = c(1, 0, 0, 1, 0, 0),
+    MDV = c(1, 0, 0, 1, 0, 0),
+    DV = c(0, 1.2, 0.8, 0, 2.1, 1.4)
+  )
+}
+
+test_that("build_keyed_residuals subsets a full-length table to observations", {
+  local_pharmr.extra_options()
+  dataset <- make_residual_test_dataset()
+  sdtab <- data.frame(
+    ID = dataset$ID,
+    TIME = dataset$TIME,
+    PRED = seq_len(6),
+    CWRES = c(0, 0.5, -0.3, 0, 1.1, -0.9),
+    CIWRES = c(0, 0.4, -0.2, 0, 1.0, -0.8)
+  )
+
+  res <- build_keyed_residuals(dataset, list(sdtab = sdtab))
+
+  expect_s3_class(res, "data.frame")
+  expect_equal(nrow(res), sum(dataset$MDV == 0))
+  expect_equal(names(res), c("ROW", "ID", "TIME", "CWRES", "CIWRES"))
+  expect_equal(res$ROW, c(2, 3, 5, 6))
+  expect_equal(res$ID, c(1, 1, 2, 2))
+  expect_equal(res$TIME, c(1, 2, 1, 2))
+  expect_equal(res$CWRES, c(0.5, -0.3, 1.1, -0.9))
+})
+
+test_that("build_keyed_residuals keeps observations with all-zero residuals", {
+  # Pharmpy drops these rows ((df != 0).any(axis=1)), which is what made
+  # nrow(fit$residuals) disagree with the observation count (#120).
+  local_pharmr.extra_options()
+  dataset <- make_residual_test_dataset()
+  sdtab <- data.frame(
+    ID = dataset$ID,
+    TIME = dataset$TIME,
+    CWRES = c(0, 0.5, 0, 0, 0, -0.9)
+  )
+
+  res <- build_keyed_residuals(dataset, list(sdtab = sdtab))
+
+  expect_equal(nrow(res), 4)
+  expect_equal(res$CWRES, c(0.5, 0, 0, -0.9))
+})
+
+test_that("build_keyed_residuals accepts observation-only tables", {
+  local_pharmr.extra_options()
+  dataset <- make_residual_test_dataset()
+  obs_table <- data.frame(
+    ID = c(1, 1, 2, 2),
+    TIME = c(1, 2, 1, 2),
+    IPRED = c(1, 2, 3, 4),
+    IWRES = c(0.1, -0.2, 0.3, -0.4)
+  )
+
+  res <- build_keyed_residuals(dataset, list(sdtab = obs_table))
+
+  expect_equal(nrow(res), 4)
+  expect_equal(res$ROW, c(2, 3, 5, 6))
+  expect_equal(res$IWRES, c(0.1, -0.2, 0.3, -0.4))
+})
+
+test_that("build_keyed_residuals aligns on ID/TIME when row counts don't match", {
+  local_pharmr.extra_options()
+  dataset <- make_residual_test_dataset()
+  partial <- data.frame(
+    ID = c(2, 1),
+    TIME = c(2, 1),
+    CWRES = c(-0.9, 0.5)
+  )
+
+  res <- build_keyed_residuals(dataset, list(sdtab = partial))
+
+  expect_equal(nrow(res), 4)
+  expect_equal(res$CWRES, c(0.5, NA, NA, -0.9))
+})
+
+test_that("build_keyed_residuals ignores tables from a different run", {
+  local_pharmr.extra_options()
+  dataset <- make_residual_test_dataset()
+  unrelated <- data.frame(
+    ID = c(7, 8, 9),
+    TIME = c(1, 2, 3),
+    CWRES = c(0.1, 0.2, 0.3)
+  )
+
+  expect_null(build_keyed_residuals(dataset, list(sdtab = unrelated)))
+})
+
+test_that("build_keyed_residuals combines columns from multiple tables", {
+  local_pharmr.extra_options()
+  dataset <- make_residual_test_dataset()
+  tables <- list(
+    sdtab = data.frame(
+      ID = dataset$ID, TIME = dataset$TIME,
+      CWRES = c(0, 0.5, -0.3, 0, 1.1, -0.9)
+    ),
+    restab = data.frame(
+      ID = dataset$ID, TIME = dataset$TIME,
+      IWRES = c(0, 0.1, -0.1, 0, 0.2, -0.2)
+    )
+  )
+
+  res <- build_keyed_residuals(dataset, tables)
+
+  expect_equal(names(res), c("ROW", "ID", "TIME", "CWRES", "IWRES"))
+  expect_equal(res$IWRES, c(0.1, -0.1, 0.2, -0.2))
+})
+
+test_that("build_keyed_residuals returns NULL when nothing usable is found", {
+  local_pharmr.extra_options()
+  dataset <- make_residual_test_dataset()
+
+  expect_null(build_keyed_residuals(dataset, list()))
+  expect_null(build_keyed_residuals(dataset, NULL))
+  expect_null(build_keyed_residuals(NULL, list(sdtab = data.frame(CWRES = 1))))
+  # table without residual columns:
+  expect_null(
+    build_keyed_residuals(
+      dataset,
+      list(patab = data.frame(ID = dataset$ID, CL = 1, V = 2))
+    )
+  )
+  # table that can neither be length-matched nor key-matched:
+  expect_null(
+    build_keyed_residuals(dataset, list(sdtab = data.frame(CWRES = c(1, 2))))
+  )
+})
+
+test_that("build_keyed_residuals falls back to EVID and to all rows", {
+  local_pharmr.extra_options()
+  dataset <- make_residual_test_dataset()
+  sdtab <- data.frame(CWRES = c(0, 0.5, -0.3, 0, 1.1, -0.9))
+
+  no_mdv <- dataset[, setdiff(names(dataset), "MDV")]
+  res_evid <- build_keyed_residuals(no_mdv, list(sdtab = sdtab))
+  expect_equal(res_evid$ROW, c(2, 3, 5, 6))
+
+  no_flags <- dataset[, c("ID", "TIME", "DV")]
+  res_all <- build_keyed_residuals(no_flags, list(sdtab = sdtab))
+  expect_equal(res_all$ROW, seq_len(6))
+})
+
+test_that("repair_residuals replaces the slot on an nlmixr2-shaped fit", {
+  local_pharmr.extra_options()
+  dataset <- make_residual_test_dataset()
+  model <- list(dataset = dataset)
+  fit <- structure(
+    list(
+      ofv = 1,
+      residuals = data.frame(CWRES = c(0.5, -0.3, 1.1, -0.9))
+    ),
+    class = c("nlmixr2_modelfit_results", "list")
+  )
+  tables <- list(
+    sdtab = data.frame(
+      ID = c(1, 1, 2, 2),
+      TIME = c(1, 2, 1, 2),
+      CWRES = c(0.5, -0.3, 1.1, -0.9)
+    )
+  )
+
+  out <- repair_residuals(fit, model, tables)
+
+  expect_s3_class(out, "nlmixr2_modelfit_results")
+  expect_equal(names(out$residuals), c("ROW", "ID", "TIME", "CWRES"))
+  expect_equal(nrow(out$residuals), 4)
+  expect_equal(out$ofv, 1)
+})
+
+test_that("repair_residuals leaves the fit untouched when tables are unusable", {
+  local_pharmr.extra_options()
+  model <- list(dataset = make_residual_test_dataset())
+  fit <- list(residuals = data.frame(CWRES = 1))
+
+  expect_equal(repair_residuals(fit, model, list()), fit)
+  expect_equal(repair_residuals(fit, NULL, list()), fit)
+  expect_null(repair_residuals(NULL, model, list()))
+})
+
+test_that("set_pharmpy_residuals replaces the slot on a Pharmpy fit", {
+  local_pharmr.extra_options()
+  skip_if_not(
+    reticulate::py_module_available("pharmpy"),
+    "Pharmpy not available"
+  )
+  model <- pharmr::load_example_model("pheno")
+  fit <- pharmr::load_example_modelfit_results("pheno")
+  dataset <- model$dataset
+  rows <- c(2, 3)
+  res <- data.frame(
+    ROW = rows,
+    ID = dataset$ID[rows],
+    TIME = dataset$TIME[rows],
+    CWRES = c(0.1, -0.2)
+  )
+
+  out <- set_pharmpy_residuals(fit, model, res)
+
+  expect_true(inherits(out, "python.builtin.object"))
+  expect_equal(nrow(out$residuals), 2)
+  expect_true(all(c("ROW", "ID", "TIME", "CWRES") %in% names(out$residuals)))
+  expect_equal(out$residuals$CWRES, c(0.1, -0.2))
+  # other slots are carried over unchanged:
+  expect_equal(out$ofv, fit$ofv)
+  expect_equal(out$parameter_estimates, fit$parameter_estimates)
+  # the pandas index is set to the dataset row labels, which is what pharmpy
+  # itself joins on:
+  py_res <- reticulate::py_get_attr(out, "residuals")
+  py_index <- reticulate::py_to_r(reticulate::py_get_attr(py_res, "index"))
+  expect_equal(as.numeric(py_index), rows - 1)
+})
+
+test_that("dataset_key_columns falls back to ID/TIME", {
+  local_pharmr.extra_options()
+  expect_equal(dataset_key_columns(list()), list(id = "ID", idv = "TIME"))
+  expect_equal(
+    dataset_key_columns(
+      list(datainfo = list(
+        id_column = list(name = "SUBJ"),
+        idv_column = list(name = "TAD")
+      ))
+    ),
+    list(id = "SUBJ", idv = "TAD")
+  )
+})


### PR DESCRIPTION
Fixes #120.

## Root cause

Pharmpy's `_parse_residuals()` (`pharmpy/tools/external/nonmem/results.py`):

```python
df = df.loc[(df != 0).any(axis=1)]  # Simple way of removing non-observations
```

Two things break for R callers:

1. **No join key.** Pharmpy keys residuals by the *pandas index* (dataset row label) — its own consumers join with `df.loc[residuals.index]`. reticulate drops the index on conversion, so nothing is left to join on in R.
2. **Row count.** The `!= 0` heuristic also drops *observation* records whose residual columns NONMEM wrote as exactly 0. `add_default_output_tables()` writes `CWRES` (plus `CIWRES`/`NPDE`), and of the three columns pharmpy inspects (`RES`, `WRES`, `CWRES`) only `CWRES` is present — so every observation with `CWRES == 0` disappeared. Hence 1134 rows against 2184 observations in the admiral popPK example.

## Fix

New `R/repair_residuals.R`:

* `build_keyed_residuals()` rebuilds the frame straight from the run's output tables: one row per observation record (`MDV == 0`, falling back to `EVID == 0`, then to all rows), with `ROW` (row number in `model$dataset`), `ID` and `TIME` key columns plus every residual column found in the tables (`RES`, `WRES`, `IRES`, `IWRES`, `CWRES`, `CIWRES`, `NPDE`, ...). Rows NONMEM reported as 0 are kept. Tables are matched by full-dataset length, by observation-only length, or on the ID/TIME key — and a table matching fewer than half the observation records is ignored as not belonging to this run.
* `repair_residuals()` writes the frame back onto the fit. `ModelfitResults` is a frozen dataclass, so a small Python helper uses `dataclasses.replace()` **and sets the new frame's pandas index to the `model.dataset` row labels**. Pharmpy code that joins on `residuals.index` (`plot_cwres_vs_idv()`) or assumes the non-observations were already filtered (`ruvsearch`) therefore keeps working — and gets better-aligned input than before. Any failure leaves the fit untouched.

Wired into `attach_fit_info()` (before the attributes are attached, since `replace()` returns a new object) and `attach_fit_info_nlmixr()`, so both engines return the same shape.

So `fit$residuals` now column-binds with `model$dataset |> filter(MDV == 0)` and `fit$predictions`, or joins on `ROW`/`ID`/`TIME`.

Also documents `run_nlme()`'s return value (was `TODO`), bumps the version and adds a NEWS entry.

## Testing

`tests/testthat/test-repair_residuals.R` — 33 tests covering full-length tables, observation-only tables (nlmixr2), key alignment, the unrelated-table guard, all-zero residuals being retained, multi-table merging, MDV/EVID fallbacks and the no-op paths. All pass.

Full suite locally: 0 failures, 1099 passes; the 255 errors are unchanged from `main` (this machine has no Pharmpy installed, so every Python-touching test errors before and after).

The Pharmpy interop path (`dataclasses.replace` + index) could not be exercised locally for the same reason — that test is gated on `reticulate::py_module_available("pharmpy")` and runs on CI.

## Follow-up

pharmaair's `test_example_modelfit_admiral.R` / `test_example_modelfit_admiral_nlmixr2.R` can restore the CWRES/IWRES GOF assertions dropped in c8ae2e7 once this is released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)