### PR TITLE
fix: use common random numbers across uncertainty draws (#131)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pharmr.extra
 Title: Extension of pharmr (Pharmpy) functionality
-Version: 0.0.0.9126
+Version: 0.0.0.9127
 Authors@R: c(
     person("Ron", "Keizer", email = "ron@insight-rx.com", role = c("cre", "aut")),
     person("Michael", "McCarthy", email = "michael.mccarthy@insight-rx.com", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,25 @@
 # pharmr.extra (development version)
 
+* `run_sim(n_uncertainty = )` with `uncertainty_engine = "replicates"` (the
+  default) now simulates **every replicate with the same `seed`** instead of a
+  per-replicate `seed + r` (#131). Both backends build ETAs and residuals by
+  scaling standard normal deviates, so a shared seed means every draw sees the
+  same underlying deviates and the only thing varying between replicates is
+  the parameter vector — the common-random-numbers setup a confidence interval
+  on a simulated percentile needs. Previously the spread across `.uncertainty`
+  also contained the Monte-Carlo noise of re-simulating a fresh set of
+  subjects for every draw, which inflated the interval. Use `n_iterations` if
+  you want fresh random variability *within* a replicate. Sequential and
+  parallel (`n_cores > 1`) runs are affected equally.
+
+  This does **not** extend to `uncertainty_engine = "nwpri"`, and cannot:
+  NONMEM continues its random sources from subproblem to subproblem and offers
+  no option to rewind them, so each NWPRI draw necessarily re-simulates its
+  own ETAs and residuals. NWPRI uncertainty intervals therefore still carry
+  that noise; make the simulation dataset large enough that it is small, or
+  use `"replicates"` when the separation matters. This is now documented on
+  `run_sim()`.
+
 * `run_sim()` gains a second parameter-uncertainty engine, selected with
   `uncertainty_engine = "nwpri"` (#130). Instead of drawing `n_uncertainty`
   parameter sets in R and running one NONMEM job per draw

--- a/R/run_sim.R
+++ b/R/run_sim.R
@@ -33,6 +33,17 @@
 #' (`nlmixr2est::bootstrapFit()`). NONMEM `$COVARIANCE` typically covers all
 #' parameters, so all are resampled.
 #'
+#' Every replicate is simulated with the **same** `seed` (common random
+#' numbers), so the sequence of standard normal deviates behind the simulated
+#' ETAs and residuals is identical across draws and the only thing that varies
+#' between replicates is the parameter vector. This is what makes a percentile
+#' computed per replicate a clean estimate of parameter uncertainty; with a
+#' different seed per replicate the spread across replicates would also contain
+#' the Monte-Carlo noise of re-simulating a fresh set of subjects each time.
+#' Use `n_iterations` if you want extra random variability *within* a
+#' replicate. Note this holds for `uncertainty_engine = "replicates"` only —
+#' see `uncertainty_engine` below for why NWPRI cannot do it.
+#'
 #' This is the same idea as NONMEM's own `$PRIOR NWPRI` +
 #' `$SIMULATION ... TRUE=PRIOR`, which is available directly as
 #' `uncertainty_engine = "nwpri"` (see below). The two are checked against each
@@ -67,8 +78,8 @@
 #' `n_uncertainty` replicates over that many worker processes. For
 #' `uncertainty_engine = "replicates"` this is supported for the `nlmixr2` tool
 #' only; a NONMEM run warns and falls back to sequential. Output is identical
-#' to a sequential run for the same `seed`, since each replicate keeps its own
-#' derived seed (`seed + r`) and results are reassembled by replicate index.
+#' to a sequential run for the same `seed`, since every replicate is run with
+#' the same `seed` and results are reassembled by replicate index.
 #' For `uncertainty_engine = "nwpri"` (NONMEM only) it sets how many NONMEM
 #' jobs the subproblems are split over, one per worker process. NONMEM's own
 #' RNG produces the draws, so *which* draws you get depends on how the
@@ -91,6 +102,15 @@
 #'   is much faster for large `n_uncertainty`. It requires `n_iterations = 1`,
 #'   because every NWPRI subproblem redraws the parameters and so cannot
 #'   repeat a draw.
+#'
+#' `"nwpri"` cannot give you common random numbers across draws. NONMEM
+#' continues its random sources from subproblem to subproblem and offers no way
+#' to rewind them, so each subproblem simulates a *different* set of ETAs and
+#' residuals in addition to a different parameter vector. Uncertainty intervals
+#' computed over `.uncertainty` from an NWPRI run therefore also contain the
+#' Monte-Carlo noise of re-simulating the subjects; make the simulation dataset
+#' large enough that this noise is small, or use `"replicates"` when a clean
+#' separation matters.
 #'
 #' The two are **not** statistically interchangeable. Over 1000 draws from the
 #' same fit their means and standard deviations agree to within a few percent
@@ -516,7 +536,18 @@ run_sim <- function(
     ))
   }
 
-  ## Replicates are independent (own draw, own seed, combined only at the end),
+  ## Common random numbers: every replicate runs with the *same* `seed`, so the
+  ## only thing that differs between replicates is the parameter draw. Both
+  ## backends generate ETA/EPS by scaling standard normal deviates, so a shared
+  ## seed means a shared sequence of deviates and therefore the same simulated
+  ## individuals (up to the draw's own OMEGA/SIGMA) in every replicate. That is
+  ## what makes a percentile computed per replicate a clean estimate of
+  ## parameter uncertainty: without it, the spread across replicates also
+  ## carries the Monte-Carlo noise of re-simulating a fresh set of subjects
+  ## each time. Use `n_iterations` (subproblems within a replicate) to add
+  ## fresh random variability on purpose. See issue #131.
+  ##
+  ## Replicates are otherwise independent (own draw, combined only at the end),
   ## so they can be spread over worker processes. Only the nlmixr2/rxode2
   ## backend is parallelised: the NONMEM backend drives Pharmpy through Python
   ## (not sendable to a worker) and writes per-regimen run folders that
@@ -542,7 +573,7 @@ run_sim <- function(
       m <- pharmr::set_initial_estimates(
         model, inits = as.list(draws[r, , drop = FALSE])
       )
-      list(index = r, code = make_nlmixr_saem_safe(m$code), seed = seed + r)
+      list(index = r, code = make_nlmixr_saem_safe(m$code), seed = seed)
     })
     ## Resolve the dataset in the parent for the same reason (it is identical
     ## across replicates, so this also avoids re-reading it per worker).
@@ -574,11 +605,12 @@ run_sim <- function(
         ## cached `nlmixr_code` attribute would otherwise make run_sim_nlmixr()
         ## silently simulate the point estimates on every replicate.
         attr(m, "nlmixr_code") <- NULL
-        ## distinct seed per draw so subproblem RNG differs between replicates.
+        ## The *same* seed for every replicate, deliberately: see the note on
+        ## common random numbers at the top of this block.
         ## `verbose = FALSE` + `suppressMessages()`: the engine's per-regimen
         ## alerts would tear down and redraw the progress bar on every
         ## replicate, and the worker path silences them the same way.
-        suppressMessages(run_sim_engine(m, seed + r, verbose = FALSE))
+        suppressMessages(run_sim_engine(m, seed, verbose = FALSE))
       })
       if(tool == "nonmem" && inherits(res$result, "condition")) {
         ## Pre-parallel behaviour, kept deliberately: NONMEM replicate failures

--- a/R/run_sim_nwpri.R
+++ b/R/run_sim_nwpri.R
@@ -8,6 +8,13 @@
 #' MPI/`PARAFILE` parallelises estimation and covariance steps only, and a
 #' simulation-only model has neither.
 #'
+#' Note that the draws do not share random numbers: NONMEM continues its random
+#' sources from subproblem to subproblem and has no option to rewind them, so
+#' every draw re-simulates its own ETAs and residuals. Unlike the
+#' `"replicates"` engine (see [run_sim()], issue #131) an NWPRI uncertainty
+#' interval therefore also carries the Monte-Carlo noise of re-simulating the
+#' subjects.
+#'
 #' So the parallelism is at the process level: split the subproblems over
 #' `n_cores` NONMEM jobs, each with its own run folder and seed, and
 #' concatenate the tables. Each chunk differs from the others only in two

--- a/man/run_sim.Rd
+++ b/man/run_sim.Rd
@@ -72,6 +72,17 @@ held fixed. For full uncertainty on those, use a bootstrap
 (\code{nlmixr2est::bootstrapFit()}). NONMEM \verb{$COVARIANCE} typically covers all
 parameters, so all are resampled.
 
+Every replicate is simulated with the \strong{same} \code{seed} (common random
+numbers), so the sequence of standard normal deviates behind the simulated
+ETAs and residuals is identical across draws and the only thing that varies
+between replicates is the parameter vector. This is what makes a percentile
+computed per replicate a clean estimate of parameter uncertainty; with a
+different seed per replicate the spread across replicates would also contain
+the Monte-Carlo noise of re-simulating a fresh set of subjects each time.
+Use \code{n_iterations} if you want extra random variability \emph{within} a
+replicate. Note this holds for \code{uncertainty_engine = "replicates"} only —
+see \code{uncertainty_engine} below for why NWPRI cannot do it.
+
 This is the same idea as NONMEM's own \verb{$PRIOR NWPRI} +
 \verb{$SIMULATION ... TRUE=PRIOR}, which is available directly as
 \code{uncertainty_engine = "nwpri"} (see below). The two are checked against each
@@ -110,8 +121,8 @@ is returned back. If \code{FALSE}, the \code{add_pk_variables} argument will be 
 \code{n_uncertainty} replicates over that many worker processes. For
 \code{uncertainty_engine = "replicates"} this is supported for the \code{nlmixr2} tool
 only; a NONMEM run warns and falls back to sequential. Output is identical
-to a sequential run for the same \code{seed}, since each replicate keeps its own
-derived seed (\code{seed + r}) and results are reassembled by replicate index.
+to a sequential run for the same \code{seed}, since every replicate is run with
+the same \code{seed} and results are reassembled by replicate index.
 For \code{uncertainty_engine = "nwpri"} (NONMEM only) it sets how many NONMEM
 jobs the subproblems are split over, one per worker process. NONMEM's own
 RNG produces the draws, so \emph{which} draws you get depends on how the
@@ -136,6 +147,15 @@ is much faster for large \code{n_uncertainty}. It requires \code{n_iterations = 
 because every NWPRI subproblem redraws the parameters and so cannot
 repeat a draw.
 }
+
+\code{"nwpri"} cannot give you common random numbers across draws. NONMEM
+continues its random sources from subproblem to subproblem and offers no way
+to rewind them, so each subproblem simulates a \emph{different} set of ETAs and
+residuals in addition to a different parameter vector. Uncertainty intervals
+computed over \code{.uncertainty} from an NWPRI run therefore also contain the
+Monte-Carlo noise of re-simulating the subjects; make the simulation dataset
+large enough that this noise is small, or use \code{"replicates"} when a clean
+separation matters.
 
 The two are \strong{not} statistically interchangeable. Over 1000 draws from the
 same fit their means and standard deviations agree to within a few percent

--- a/tests/testthat/test-run_sim-common-random-numbers.R
+++ b/tests/testthat/test-run_sim-common-random-numbers.R
@@ -1,0 +1,161 @@
+# Common random numbers across uncertainty draws (#131) -----------------------
+#
+# Every `n_uncertainty` replicate of the `"replicates"` engine must be
+# simulated with the *same* seed, so the sequence of standard normal deviates
+# behind the simulated ETAs and residuals is shared across draws and the only
+# thing that varies between replicates is the parameter vector. That is what
+# makes a percentile computed per replicate a clean estimate of parameter
+# uncertainty rather than a mixture of that and Monte-Carlo noise.
+
+## Replicated point estimates: stands in for `sample_uncertainty_parameters()`
+## when a test wants every replicate to get an *identical* parameter draw, so
+## any remaining difference between replicates can only come from the seed.
+.identical_draws <- function(model, parameter_estimates, covariance_matrix,
+                             n, seed) {
+  pe <- unlist(parameter_estimates)
+  nms <- intersect(names(pe), colnames(as.matrix(covariance_matrix)))
+  as.data.frame(matrix(
+    rep(pe[nms], each = n), nrow = n, dimnames = list(NULL, nms)
+  ))
+}
+
+.crn_nlmixr_case <- function() {
+  fx <- readRDS(test_path("fixtures", "nlmixr2_pheno_focei_fit.rds"))
+  mod <- pharmr::convert_model(pharmr::load_example_model("pheno"), "nlmixr")
+  dat <- as.data.frame(mod$dataset)
+  dat$EVID <- ifelse(dat$AMT > 0, 1, 0)
+  dat$MDV  <- ifelse(dat$DV == 0, 1, 0)
+  list(
+    model = mod,
+    data = dat,
+    fit = list(
+      parameter_estimates = fx$parameter_estimates,
+      covariance_matrix   = fx$covariance_matrix
+    )
+  )
+}
+
+test_that("run_sim (nlmixr2): identical draws give identical replicates", {
+  local_pharmr.extra_options()
+  skip_if_nonmem_not_available()
+  skip_if_not_installed("rxode2")
+  skip_on_cran()
+  ## fixture first: `local_dir()` would break the relative `test_path()`
+  case <- .crn_nlmixr_case()
+  withr::local_dir(tempdir())
+  local_mocked_bindings(
+    sample_uncertainty_parameters = .identical_draws,
+    .package = "pharmr.extra"
+  )
+
+  out <- suppressWarnings(run_sim(
+    fit = case$fit, model = case$model, data = case$data, tool = "nlmixr2",
+    n_uncertainty = 3, n_iterations = 1, seed = 4321, verbose = FALSE
+  ))
+
+  by_rep <- split(out$DV, out$.uncertainty)
+  expect_length(by_rep, 3)
+  ## Same parameters + same seed => the same simulated subjects, so the
+  ## replicates must agree exactly. A per-replicate seed would break this.
+  expect_equal(by_rep[[2]], by_rep[[1]])
+  expect_equal(by_rep[[3]], by_rep[[1]])
+  ## ...and the simulation really is stochastic, so the check above is not
+  ## satisfied trivially by a deterministic model: a different base seed gives
+  ## different subjects.
+  out2 <- suppressWarnings(run_sim(
+    fit = case$fit, model = case$model, data = case$data, tool = "nlmixr2",
+    n_uncertainty = 3, n_iterations = 1, seed = 9999, verbose = FALSE
+  ))
+  expect_false(isTRUE(all.equal(split(out2$DV, out2$.uncertainty)[[1]],
+                                by_rep[[1]])))
+})
+
+test_that("run_sim (nlmixr2): differing draws still differ under a shared seed", {
+  local_pharmr.extra_options()
+  skip_if_nonmem_not_available()
+  skip_if_not_installed("rxode2")
+  skip_on_cran()
+  ## fixture first: `local_dir()` would break the relative `test_path()`
+  case <- .crn_nlmixr_case()
+  withr::local_dir(tempdir())
+  out <- suppressWarnings(run_sim(
+    fit = case$fit, model = case$model, data = case$data, tool = "nlmixr2",
+    n_uncertainty = 3, n_iterations = 1, seed = 4321, verbose = FALSE
+  ))
+
+  by_rep <- split(out$DV, out$.uncertainty)
+  ## Sharing the seed must not collapse the draws: the parameter vectors still
+  ## differ, so the replicates do too.
+  expect_false(isTRUE(all.equal(by_rep[[2]], by_rep[[1]])))
+  expect_false(isTRUE(all.equal(by_rep[[3]], by_rep[[1]])))
+})
+
+test_that("run_sim (nlmixr2): every parallel replicate spec carries the base seed", {
+  local_pharmr.extra_options()
+  skip_if_nonmem_not_available()
+  skip_if_not_installed("rxode2")
+  skip_on_cran()
+  ## fixture first: `local_dir()` would break the relative `test_path()`
+  case <- .crn_nlmixr_case()
+  withr::local_dir(tempdir())
+  seen_specs <- NULL
+  local_mocked_bindings(
+    ## Run the replicates in-process, but record what the parallel path handed
+    ## to the workers.
+    parallel_lapply = function(x, fn, n_cores, ...) {
+      seen_specs <<- x
+      lapply(x, fn)
+    },
+    .package = "pharmr.extra"
+  )
+
+  suppressWarnings(run_sim(
+    fit = case$fit, model = case$model, data = case$data, tool = "nlmixr2",
+    n_uncertainty = 3, n_iterations = 1, seed = 4321, n_cores = 2,
+    verbose = FALSE
+  ))
+
+  expect_length(seen_specs, 3)
+  expect_equal(vapply(seen_specs, function(s) s$seed, numeric(1)), rep(4321, 3))
+  ## the specs do differ where they should: one model per draw
+  expect_equal(length(unique(vapply(seen_specs, function(s) s$code, character(1)))), 3)
+})
+
+test_that("run_sim (nonmem): every replicate is simulated with the base seed", {
+  local_pharmr.extra_options()
+  skip_if_nonmem_not_available()
+  withr::local_dir(tempdir())
+
+  mod <- make_model_without_cov()
+  fake_fit <- list(
+    parameter_estimates = c(POP_CL = 1, POP_V = 10),
+    covariance_matrix   = diag(2)
+  )
+  seeds <- c()
+  local_mocked_bindings(
+    run_nlme = function(...) .mock_nlme_result(),
+    sample_uncertainty_parameters =
+      function(model, parameter_estimates, covariance_matrix, n, seed) {
+        as.data.frame(matrix(rep(seq_len(n), 2), ncol = 2,
+                             dimnames = list(NULL, c("POP_CL", "POP_V"))))
+      },
+    ## The seed reaches NONMEM through the `$SIMULATION` record, which is what
+    ## this writes; record it instead of parsing the control stream back.
+    set_simulation_clean = function(model, seed, n, ...) {
+      seeds <<- c(seeds, seed)
+      model
+    },
+    .package = "pharmr.extra"
+  )
+  local_mocked_bindings(
+    set_initial_estimates = function(model, inits) model,
+    .package = "pharmr"
+  )
+
+  out <- run_sim(fit = fake_fit, model = mod, data = .sim_dat(),
+                 n_uncertainty = 3, seed = 777, verbose = FALSE)
+
+  expect_equal(sort(unique(out$.uncertainty)), 1:3)
+  ## one $SIMULATION record per replicate (single regimen), all on the same seed
+  expect_equal(seeds, rep(777, 3))
+})

--- a/tests/testthat/test-run_sim-parallel.R
+++ b/tests/testthat/test-run_sim-parallel.R
@@ -156,11 +156,11 @@ test_that("nlmixr2 replicates give identical results run in parallel or not", {
   }, error = function(e) FALSE)
   skip_if_not(cl_ok, "cannot start a PSOCK cluster")
 
-  ## Mirrors run_sim(): one spec per replicate, each with its own draw and its
-  ## own derived seed.
+  ## Mirrors run_sim(): one spec per replicate, each with its own draw but all
+  ## on the same seed (common random numbers, #131).
   draws <- c(0.5, 1, 2, 4)
   specs <- lapply(seq_along(draws), function(r) {
-    list(index = r, code = .nlmixr_code(draws[r]), seed = 100 + r)
+    list(index = r, code = .nlmixr_code(draws[r]), seed = 100)
   })
   fn <- make_nlmixr_replicate_fn(
     data = .rx_sim_dat(), n_iterations = 2, variables = NULL,


### PR DESCRIPTION
Closes #131 for the `"replicates"` engine, and documents why the `"nwpri"` engine cannot follow.

## The bug

`run_sim(n_uncertainty = )` with `uncertainty_engine = "replicates"` ran each replicate with its own derived seed (`seed + r`). Every parameter draw was therefore applied to a *freshly simulated* set of subjects, so the spread across `.uncertainty` contained parameter uncertainty **plus** the Monte-Carlo noise of re-simulating ETAs and residuals per draw. Any CI computed over the replicates was inflated by that second component.

## The fix

Every replicate is now simulated with the base `seed`. Both backends build ETAs and residuals by scaling standard normal deviates, so a shared seed means a shared sequence of deviates: the simulated individuals are identical across replicates (up to that draw's OMEGA/SIGMA), and the parameter vector is the only thing that varies. That is the common-random-numbers setup a CI on a simulated percentile needs.

`n_iterations` remains the way to add fresh random variability *within* a replicate. Sequential and parallel (`n_cores > 1`) paths are changed identically, so `n_cores` still has no effect on the output.

## NWPRI: not fixable, documented instead

NONMEM Users Guide VIII, `$SIMULATION`:

> Each subproblem includes the Simulation Step, but the random sources are simply continued from subproblem to subproblem.

There is no option to rewind them — `NEW` controls whether `SIMETA`/`SIMEPS` redraw per call rather than per individual record, and `REWIND`/`NOREWIND` is about the data set. So under `TRUE=PRIOR` each subproblem redraws the parameter vector *and* a new set of ETAs/EPS, and NWPRI uncertainty intervals necessarily carry the re-simulation noise.

Getting around it would mean pre-simulating standardized ETAs into data columns and reconstructing `chol(OMEGA_draw) %*% z` in `$PK` against NONMEM's inverse-Wishart draw — fragile, and awkward for BLOCK omegas. Not attempted here. The limitation is documented on `run_sim()`'s `uncertainty_engine` parameter, on `run_nwpri_regimen()`, and in `NEWS.md`, with the guidance to size the simulation dataset so the noise is small or to use `"replicates"` when the separation matters.

## Tests

New `tests/testthat/test-run_sim-common-random-numbers.R`:

- nlmixr2, mocked identical draws → replicates come out identical; guarded against vacuity by showing a different base seed gives different output
- nlmixr2, real draws → replicates still differ under the shared seed (seed sharing does not collapse the draws)
- parallel path → every replicate spec carries the base seed, with distinct model code per draw
- NONMEM path → the `$SIMULATION` seed recorded per replicate is the base seed for all of them

All four fail on the old `seed + r` behaviour (verified by reverting). Full suite: 0 failed, 0 errors, 2338 passed, 115 skipped (skips are the usual "NONMEM/Pharmpy not configured" gates locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
