### PR TITLE
feat: default to the NWPRI uncertainty engine, harden worker startup (#134)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pharmr.extra
 Title: Extension of pharmr (Pharmpy) functionality
-Version: 0.0.0.9127
+Version: 0.0.0.9128
 Authors@R: c(
     person("Ron", "Keizer", email = "ron@insight-rx.com", role = c("cre", "aut")),
     person("Michael", "McCarthy", email = "michael.mccarthy@insight-rx.com", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,48 @@
 # pharmr.extra (development version)
 
+* **Breaking-ish:** `run_sim(n_uncertainty = )` now defaults to
+  `uncertainty_engine = "auto"`, which uses **NWPRI** wherever it applies —
+  NONMEM, with `n_iterations = 1` — and `"replicates"` everywhere else (#134).
+  Benchmarked against the previous default on a 1-cmt oral model with a
+  700-row simulation dataset and `n_cores = 4`: 18.6 s -> 4.3 s at 50 draws,
+  65.3 s -> 5.1 s at 200, and 339.2 s -> 9.2 s at 1000. The replicate loop pays
+  a full NM-TRAN + compile + run per draw, so its cost is linear in
+  `n_uncertainty`; NWPRI pays one compile per chunk and is close to flat.
+  `n_cores` never helped the replicate loop on NONMEM in the first place (it
+  warns and runs sequentially), so this is where the parallelism actually
+  arrives for that backend.
+
+  Naming an engine explicitly still errors rather than falling back, so an
+  explicit `uncertainty_engine = "nwpri"` on an nlmixr2 run or with
+  `n_iterations > 1` fails exactly as before. `"auto"` announces its choice
+  under `verbose`.
+
+  Two consequences worth knowing, both documented on `run_sim()`. NWPRI draws
+  OMEGA/SIGMA from inverse-Wishart distributions and drops the THETA-OMEGA and
+  THETA-SIGMA covariances `$COVARIANCE` reports, so draws are not distributed
+  identically to the `"replicates"` engine's (aggregates agree to within a few
+  percent; see `inst/reports/nwpri-validation.html`). And NWPRI cannot hold the
+  simulated individuals fixed across draws the way `"replicates"` now does
+  (#131), so an interval over `.uncertainty` also carries the Monte-Carlo noise
+  of re-simulating the subjects — which shrinks as the dataset and
+  `n_uncertainty` grow. Pass `uncertainty_engine = "replicates"` to get the old
+  behaviour back.
+
+* Parallel worker startup is no longer able to take down a whole run (#134).
+  Bringing up the cluster happens before any work function is called, so it sat
+  outside `run_captured()`'s error handling: an intermittent failure in a
+  worker's `loadNamespace()` (seen inside rxode2's `.onLoad`) aborted the
+  entire `run_sim()` call rather than costing one chunk. `parallel_lapply()`
+  now retries once and then falls back to running everything sequentially with
+  a warning. Same results either way, only slower.
+
+* The NWPRI engine no longer splits the draws over more NONMEM jobs than the
+  split is worth (#134). Each extra chunk costs a worker process to start and
+  load the package (~1.4 s for four) against ~0.02 s per subproblem, so below
+  ~50 draws per chunk the chunking made the run slower — measured at 2.6 s in
+  one job versus 4.3 s over four for 50 draws. `n_cores` is now a ceiling
+  rather than a target.
+
 * `run_sim(n_uncertainty = )` with `uncertainty_engine = "replicates"` (the
   default) now simulates **every replicate with the same `seed`** instead of a
   per-replicate `seed + r` (#131). Both backends build ETAs and residuals by

--- a/R/parallel_replicates.R
+++ b/R/parallel_replicates.R
@@ -38,10 +38,21 @@ resolve_n_cores <- function(n_cores) {
 #' Results are returned in the order of `X` regardless of how work was
 #' scheduled, so callers can rely on positional indexing.
 #'
+#' Starting the workers is best-effort: bringing a cluster up is a separate
+#' failure mode from the work itself, and it is one this package has seen fail
+#' intermittently (#134 — a worker's `loadNamespace()` failing inside rxode2's
+#' `.onLoad`). Because it happens before `FUN` is ever called it is outside
+#' whatever error handling the caller wrapped `FUN` in, so left unguarded it
+#' takes down the entire run rather than costing one item. Rather than let a
+#' transient startup problem throw away the work, a failed attempt is retried
+#' once and then falls back to running everything sequentially in this process:
+#' slower, but the same results.
+#'
 #' @param X vector/list to iterate over.
 #' @param FUN function applied to each element. Must be self-contained enough
 #' to survive serialisation to a worker (no Python/reticulate objects, no
-#' open connections).
+#' open connections). Must also be safe to call again from scratch: a parallel
+#' attempt that fails part-way is redone sequentially.
 #' @param n_cores number of worker processes; `1` runs sequentially in-process.
 #'
 #' @returns list of results, one per element of `X`, in the order of `X`.
@@ -51,14 +62,40 @@ parallel_lapply <- function(X, FUN, n_cores = 1L) {
     return(lapply(X, FUN))
   }
   n_workers <- min(n_cores, length(X))
-  cl <- parallel::makePSOCKcluster(n_workers)
-  on.exit(parallel::stopCluster(cl), add = TRUE)
-  init <- worker_init_args()
-  ## Reparented to baseenv() on purpose: a closure carrying this package's
-  ## namespace makes the worker load the *installed* pharmr.extra just to
-  ## unserialise it, which fails when the package was never installed and
-  ## silently runs stale code when it was. This one loads nothing implicitly,
-  ## so it gets to decide which copy the worker uses.
+
+  attempt <- function() {
+    cl <- parallel::makePSOCKcluster(n_workers)
+    on.exit(parallel::stopCluster(cl), add = TRUE)
+    init <- worker_init_args()
+    parallel::clusterCall(cl, worker_init_fn(), init$path, init$dev,
+                          worker_threads(n_workers))
+    parallel::parLapplyLB(cl, X, FUN)
+  }
+
+  for(try_n in 1:2) {
+    res <- tryCatch(attempt(), error = function(e) e)
+    if(!inherits(res, "condition")) return(res)
+    if(try_n == 1L) next
+    cli::cli_warn(c(
+      "Could not run on {n_workers} worker process{?es}; running sequentially.",
+      x = conditionMessage(res),
+      i = "The results are the same either way, only slower."
+    ))
+  }
+  lapply(X, FUN)
+}
+
+#' The function each worker runs before any work is handed to it
+#'
+#' A factory returning a `baseenv()`-parented closure, on purpose: a closure
+#' carrying this package's namespace makes the worker load the *installed*
+#' pharmr.extra just to unserialise it, which fails when the package was never
+#' installed and silently runs stale code when it was. This one loads nothing
+#' implicitly, so it gets to decide which copy the worker uses.
+#'
+#' @returns a function of `(path, dev, threads)`.
+#' @noRd
+worker_init_fn <- function() {
   init_fn <- function(path, dev, threads) {
     if(isTRUE(dev)) {
       pkgload::load_all(path, quiet = TRUE, helpers = FALSE,
@@ -76,9 +113,7 @@ parallel_lapply <- function(X, FUN, n_cores = 1L) {
     invisible(NULL)
   }
   environment(init_fn) <- baseenv()
-  parallel::clusterCall(cl, init_fn, init$path, init$dev,
-                        worker_threads(n_workers))
-  parallel::parLapplyLB(cl, X, FUN)
+  init_fn
 }
 
 #' Solver threads to allow each worker process

--- a/R/run_sim.R
+++ b/R/run_sim.R
@@ -42,7 +42,8 @@
 #' the Monte-Carlo noise of re-simulating a fresh set of subjects each time.
 #' Use `n_iterations` if you want extra random variability *within* a
 #' replicate. Note this holds for `uncertainty_engine = "replicates"` only —
-#' see `uncertainty_engine` below for why NWPRI cannot do it.
+#' see `uncertainty_engine` below for why NWPRI cannot do it, and why it is
+#' nonetheless the default.
 #'
 #' This is the same idea as NONMEM's own `$PRIOR NWPRI` +
 #' `$SIMULATION ... TRUE=PRIOR`, which is available directly as
@@ -91,9 +92,14 @@
 #' @param uncertainty_engine how `n_uncertainty` parameter uncertainty is
 #' propagated. Ignored when no uncertainty is requested.
 #'
-#' * `"replicates"` (default, unchanged behaviour) draws `n_uncertainty`
-#'   parameter sets from the fit's covariance matrix in R and runs one
-#'   simulation per draw. Works for both backends.
+#' * `"auto"` (default) uses `"nwpri"` where it applies — NONMEM, with
+#'   `n_iterations = 1` — and `"replicates"` everywhere else. Naming an engine
+#'   explicitly errors rather than falling back, so an explicit request is
+#'   never silently overridden; `"auto"` announces which one it picked under
+#'   `verbose`.
+#' * `"replicates"` draws `n_uncertainty` parameter sets from the fit's
+#'   covariance matrix in R and runs one simulation per draw. Works for both
+#'   backends.
 #' * `"nwpri"` (NONMEM only) hands the job to NONMEM: a `$PRIOR NWPRI` record
 #'   built from the fit (see [add_nwpri_prior()]) plus
 #'   `$SIMULATION ... TRUE=PRIOR`, so NONMEM draws a new parameter vector per
@@ -122,8 +128,19 @@
 #' the THETA-OMEGA and THETA-SIGMA covariances that `$COVARIANCE` reports.
 #' Which is preferable is a judgement call — the inverse-Wishart draw is
 #' arguably better justified for variance parameters, joint sampling is the one
-#' that keeps the full reported covariance — which is why this is a switch
-#' rather than a silent optimisation.
+#' that keeps the full reported covariance — which is why this stays a switch
+#' rather than becoming an implementation detail.
+#'
+#' A third difference matters for uncertainty intervals specifically: NWPRI
+#' cannot hold the simulated individuals fixed across draws, where
+#' `"replicates"` does (see `n_uncertainty` above, and issue #131). An NWPRI
+#' interval over `.uncertainty` therefore also carries the Monte-Carlo noise of
+#' re-simulating the subjects. That noise shrinks as the simulation dataset and
+#' `n_uncertainty` grow, which is the regime the speed difference makes
+#' practical, so NWPRI is nonetheless the default. Use
+#' `uncertainty_engine = "replicates"` when a clean separation matters more
+#' than run time — small simulation datasets and few draws being the case to
+#' watch.
 #' @param plev `uncertainty_engine = "nwpri"` only: the probability mass the
 #' THETA draws are truncated to, passed to [add_nwpri_prior()].
 #'
@@ -159,7 +176,7 @@ run_sim <- function(
     ## before, and callers passing it positionally would otherwise silently
     ## set `n_cores` instead.
     n_cores = 1,
-    uncertainty_engine = c("replicates", "nwpri"),
+    uncertainty_engine = c("auto", "replicates", "nwpri"),
     plev = 0.9999
 ) {
 
@@ -234,7 +251,20 @@ run_sim <- function(
 
   ## Which uncertainty engine. Only meaningful when uncertainty was asked for,
   ## so an engine set on a point-estimate run is simply unused.
+  ##
+  ## `"auto"` (the default) prefers NWPRI, which is the faster engine by a wide
+  ## margin — one NONMEM compile for the whole set of draws instead of one per
+  ## draw, measured at 37x for 1000 draws of a small model (#134) — and falls
+  ## back to `"replicates"` wherever NWPRI cannot be used. Asking for an engine
+  ## by name still errors rather than falling back, so an explicit request is
+  ## never silently overridden.
   uncertainty_engine <- match.arg(uncertainty_engine)
+  if(uncertainty_engine == "auto") {
+    uncertainty_engine <- resolve_uncertainty_engine(
+      tool = tool, n_iterations = n_iterations,
+      verbose = verbose && !is.null(n_uncertainty)
+    )
+  }
   use_nwpri <- !is.null(n_uncertainty) && uncertainty_engine == "nwpri"
   if(use_nwpri) {
     if(tool != "nonmem") {

--- a/R/run_sim_nwpri.R
+++ b/R/run_sim_nwpri.R
@@ -56,9 +56,10 @@ run_nwpri_regimen <- function(
     force = FALSE,
     verbose = TRUE
 ) {
-  sizes   <- nwpri_chunk_sizes(n_uncertainty, n_cores)
-  seeds   <- nwpri_chunk_seeds(seed, length(sizes))
-  offsets <- cumsum(c(0L, utils::head(sizes, -1L)))
+  n_chunks <- nwpri_worker_count(n_uncertainty, n_cores)
+  sizes    <- nwpri_chunk_sizes(n_uncertainty, n_chunks)
+  seeds    <- nwpri_chunk_seeds(seed, length(sizes))
+  offsets  <- cumsum(c(0L, utils::head(sizes, -1L)))
 
   ## Folders are created and control streams written here rather than in the
   ## workers: `create_run_folder()` carries the `force` semantics used
@@ -94,8 +95,7 @@ run_nwpri_regimen <- function(
 
   if(verbose) {
     cli::cli_alert_info(
-      "Running {n_uncertainty} NWPRI draw{?s} in {length(specs)} NONMEM \\
-       job{?s} on {n_cores} core{?s}"
+      "Running {n_uncertainty} NWPRI draw{?s} in {length(specs)} NONMEM job{?s}"
     )
   }
   chunks <- parallel_lapply(
@@ -243,6 +243,43 @@ nwpri_draws_kept <- function(out) {
   )
   as.integer(min(per_regimen))
 }
+
+#' How many NONMEM jobs the subproblems are actually worth splitting over
+#'
+#' `n_cores` is a ceiling, not a target. Every extra chunk buys one more
+#' concurrent NONMEM process but costs a worker process that has to start up
+#' and load this package, measured at ~1.4 s for four workers, against a
+#' marginal cost of ~0.02 s per subproblem for a small model. Below roughly
+#' `NWPRI_MIN_DRAWS_PER_CHUNK` draws per chunk the startup is the larger
+#' number and chunking makes the run slower: benchmarking 50 draws of a 1-cmt
+#' model took 2.6 s in one job and 4.3 s split over four (#134).
+#'
+#' Note this makes the draws depend on `n_uncertainty` as well as `n_cores`,
+#' since NONMEM's RNG produces them per chunk — see `nwpri_chunk_seeds()`.
+#'
+#' @param n total number of draws.
+#' @param n_cores the caller's `n_cores`, an upper bound on the chunk count.
+#'
+#' @returns a positive integer, never more than `n_cores` or `n`.
+#' @noRd
+nwpri_worker_count <- function(n, n_cores) {
+  n <- as.integer(n)
+  n_cores <- as.integer(n_cores)
+  if(is.na(n) || n < 1L) {
+    cli::cli_abort("Number of NWPRI draws must be a positive integer.")
+  }
+  if(is.na(n_cores) || n_cores < 1L) {
+    cli::cli_abort("Number of NWPRI chunks must be a positive integer.")
+  }
+  min(n_cores, max(1L, n %/% NWPRI_MIN_DRAWS_PER_CHUNK))
+}
+
+#' Fewest draws that justify giving a chunk its own worker process
+#'
+#' See `nwpri_worker_count()`. Derived from the measured worker startup cost
+#' over the measured per-subproblem cost, rounded to something memorable.
+#' @noRd
+NWPRI_MIN_DRAWS_PER_CHUNK <- 50L
 
 #' Split `n` subproblems over `n_chunks` NONMEM jobs
 #'
@@ -396,4 +433,55 @@ run_nwpri_regimen_tables <- function(
   }
 
   stats::setNames(list(tab), table_name)
+}
+
+#' Pick the uncertainty engine for `uncertainty_engine = "auto"`
+#'
+#' NWPRI where it can be used, `"replicates"` everywhere else. NWPRI is the
+#' faster engine by a wide margin — its cost is roughly flat in
+#' `n_uncertainty` where the replicate loop pays a NONMEM compile per draw —
+#' so it is the better default whenever it applies. It applies only to NONMEM,
+#' and only with `n_iterations = 1`, because every `$SIMULATION` subproblem
+#' under `TRUE=PRIOR` redraws the parameters and so cannot repeat a draw.
+#'
+#' Unlike an explicit `uncertainty_engine = "nwpri"`, which errors when it
+#' cannot be honoured, `"auto"` falls back silently-but-audibly: the choice is
+#' announced under `verbose` so a run that quietly took the slower route is
+#' still visible.
+#'
+#' Note the two engines are not statistically interchangeable, and NWPRI is
+#' the one that cannot hold the simulated individuals fixed across draws (see
+#' [run_sim()], issues #131 and #134). That is a deliberate trade for the
+#' speed; use `uncertainty_engine = "replicates"` where it matters.
+#'
+#' @param tool resolved simulation tool, `"nonmem"` or `"nlmixr2"`.
+#' @param n_iterations the caller's `n_iterations`.
+#' @param verbose announce the choice?
+#'
+#' @returns `"nwpri"` or `"replicates"`.
+#' @noRd
+resolve_uncertainty_engine <- function(tool, n_iterations, verbose = TRUE) {
+  if(tool != "nonmem") {
+    if(verbose) {
+      cli::cli_alert_info(
+        "Using the {.val replicates} uncertainty engine \\
+         ({.code $PRIOR NWPRI} is a NONMEM feature; this runs in {.val {tool}})."
+      )
+    }
+    return("replicates")
+  }
+  if(n_iterations != 1) {
+    if(verbose) {
+      cli::cli_alert_info(
+        "Using the {.val replicates} uncertainty engine \\
+         ({.code n_iterations = {n_iterations}}; NWPRI redraws the parameters \\
+         every subproblem and so needs {.code n_iterations = 1})."
+      )
+    }
+    return("replicates")
+  }
+  if(verbose) {
+    cli::cli_alert_info("Using the {.val nwpri} uncertainty engine.")
+  }
+  "nwpri"
 }

--- a/man/run_sim.Rd
+++ b/man/run_sim.Rd
@@ -21,7 +21,7 @@ run_sim(
   seed = 12345,
   verbose = TRUE,
   n_cores = 1,
-  uncertainty_engine = c("replicates", "nwpri"),
+  uncertainty_engine = c("auto", "replicates", "nwpri"),
   plev = 0.9999
 )
 }
@@ -81,7 +81,8 @@ different seed per replicate the spread across replicates would also contain
 the Monte-Carlo noise of re-simulating a fresh set of subjects each time.
 Use \code{n_iterations} if you want extra random variability \emph{within} a
 replicate. Note this holds for \code{uncertainty_engine = "replicates"} only —
-see \code{uncertainty_engine} below for why NWPRI cannot do it.
+see \code{uncertainty_engine} below for why NWPRI cannot do it, and why it is
+nonetheless the default.
 
 This is the same idea as NONMEM's own \verb{$PRIOR NWPRI} +
 \verb{$SIMULATION ... TRUE=PRIOR}, which is available directly as
@@ -135,9 +136,14 @@ not oversubscribe the CPU.}
 \item{uncertainty_engine}{how \code{n_uncertainty} parameter uncertainty is
 propagated. Ignored when no uncertainty is requested.
 \itemize{
-\item \code{"replicates"} (default, unchanged behaviour) draws \code{n_uncertainty}
-parameter sets from the fit's covariance matrix in R and runs one
-simulation per draw. Works for both backends.
+\item \code{"auto"} (default) uses \code{"nwpri"} where it applies — NONMEM, with
+\code{n_iterations = 1} — and \code{"replicates"} everywhere else. Naming an engine
+explicitly errors rather than falling back, so an explicit request is
+never silently overridden; \code{"auto"} announces which one it picked under
+\code{verbose}.
+\item \code{"replicates"} draws \code{n_uncertainty} parameter sets from the fit's
+covariance matrix in R and runs one simulation per draw. Works for both
+backends.
 \item \code{"nwpri"} (NONMEM only) hands the job to NONMEM: a \verb{$PRIOR NWPRI} record
 built from the fit (see \code{\link[=add_nwpri_prior]{add_nwpri_prior()}}) plus
 \verb{$SIMULATION ... TRUE=PRIOR}, so NONMEM draws a new parameter vector per
@@ -167,8 +173,19 @@ THETA, OMEGA and SIGMA priors as independent blocks and therefore discards
 the THETA-OMEGA and THETA-SIGMA covariances that \verb{$COVARIANCE} reports.
 Which is preferable is a judgement call — the inverse-Wishart draw is
 arguably better justified for variance parameters, joint sampling is the one
-that keeps the full reported covariance — which is why this is a switch
-rather than a silent optimisation.}
+that keeps the full reported covariance — which is why this stays a switch
+rather than becoming an implementation detail.
+
+A third difference matters for uncertainty intervals specifically: NWPRI
+cannot hold the simulated individuals fixed across draws, where
+\code{"replicates"} does (see \code{n_uncertainty} above, and issue #131). An NWPRI
+interval over \code{.uncertainty} therefore also carries the Monte-Carlo noise of
+re-simulating the subjects. That noise shrinks as the simulation dataset and
+\code{n_uncertainty} grow, which is the regime the speed difference makes
+practical, so NWPRI is nonetheless the default. Use
+\code{uncertainty_engine = "replicates"} when a clean separation matters more
+than run time — small simulation datasets and few draws being the case to
+watch.}
 
 \item{plev}{\code{uncertainty_engine = "nwpri"} only: the probability mass the
 THETA draws are truncated to, passed to \code{\link[=add_nwpri_prior]{add_nwpri_prior()}}.}

--- a/tests/testthat/test-run_sim-common-random-numbers.R
+++ b/tests/testthat/test-run_sim-common-random-numbers.R
@@ -153,7 +153,8 @@ test_that("run_sim (nonmem): every replicate is simulated with the base seed", {
   )
 
   out <- run_sim(fit = fake_fit, model = mod, data = .sim_dat(),
-                 n_uncertainty = 3, seed = 777, verbose = FALSE)
+                 n_uncertainty = 3, seed = 777,
+                 uncertainty_engine = "replicates", verbose = FALSE)
 
   expect_equal(sort(unique(out$.uncertainty)), 1:3)
   ## one $SIMULATION record per replicate (single regimen), all on the same seed

--- a/tests/testthat/test-run_sim-engine-default.R
+++ b/tests/testthat/test-run_sim-engine-default.R
@@ -1,0 +1,133 @@
+# Default uncertainty engine and worker-init resilience (#134) -----------------
+#
+# `uncertainty_engine = "auto"` (the default) prefers NWPRI, which benchmarks
+# far faster than the replicate loop, and falls back to `"replicates"` wherever
+# NWPRI cannot be used. Naming an engine explicitly must still error rather
+# than fall back, so an explicit request is never silently overridden.
+
+test_that("resolve_uncertainty_engine picks nwpri only where it applies", {
+  expect_equal(resolve_uncertainty_engine("nonmem", 1, verbose = FALSE), "nwpri")
+  ## NWPRI is a NONMEM feature
+  expect_equal(resolve_uncertainty_engine("nlmixr2", 1, verbose = FALSE),
+               "replicates")
+  ## every NWPRI subproblem redraws the parameters, so it cannot repeat a draw
+  expect_equal(resolve_uncertainty_engine("nonmem", 2, verbose = FALSE),
+               "replicates")
+})
+
+test_that("resolve_uncertainty_engine says which engine it picked", {
+  expect_message(resolve_uncertainty_engine("nonmem", 1), "nwpri")
+  ## and why, when it could not use NWPRI
+  expect_message(resolve_uncertainty_engine("nlmixr2", 1), "NONMEM feature")
+  expect_message(resolve_uncertainty_engine("nonmem", 3), "n_iterations")
+  expect_silent(resolve_uncertainty_engine("nonmem", 1, verbose = FALSE))
+})
+
+## The NWPRI engine returns a named list of tables per regimen, simulation
+## table first; this stands in for one.
+.stub_nwpri_tables <- function(n_uncertainty = 2L) {
+  tab <- do.call(rbind, lapply(seq_len(n_uncertainty), function(k) {
+    data.frame(ID = 1L, TIME = c(0, 6, 12), DV = c(0, 5, 3),
+               EVID = c(1L, 0L, 0L), .uncertainty = k)
+  }))
+  list(simtab = tab)
+}
+
+## Bindings that stub out everything needing a real NONMEM/pharmpy install, so
+## the tests only observe *which branch ran*. Returned rather than applied, so
+## each test can install them in its own frame (this testthat has no
+## `.local_envir` argument).
+.nwpri_stub_bindings <- function(used) {
+  list(
+    get_nmfe_location = function(...) "/nonexistent/nmfe",
+    add_nwpri_prior = function(model, fit, ...) model,
+    run_nwpri_regimen_tables = function(...) {
+      used$engine <- "nwpri"
+      .stub_nwpri_tables()
+    },
+    run_nlme = function(...) {
+      used$engine <- "replicates"
+      .mock_nlme_result()
+    },
+    sample_uncertainty_parameters =
+      function(model, parameter_estimates, covariance_matrix, n, seed) {
+        as.data.frame(matrix(rep(seq_len(n), 2), ncol = 2,
+                             dimnames = list(NULL, c("POP_CL", "POP_V"))))
+      },
+    .package = "pharmr.extra"
+  )
+}
+
+.fake_fit <- function() {
+  list(parameter_estimates = c(POP_CL = 1, POP_V = 10),
+       covariance_matrix = diag(2))
+}
+
+test_that("run_sim (nonmem): the default engine is now nwpri", {
+  local_pharmr.extra_options()
+  skip_if_nonmem_not_available()
+  withr::local_dir(tempdir())
+
+  used <- new.env()
+  do.call(local_mocked_bindings, .nwpri_stub_bindings(used))
+  local_mocked_bindings(set_initial_estimates = function(model, inits) model,
+                        .package = "pharmr")
+  out <- run_sim(
+    fit = .fake_fit(), model = make_model_without_cov(), data = .sim_dat(),
+    n_uncertainty = 2, verbose = FALSE
+  )
+  expect_equal(used$engine, "nwpri")
+  expect_equal(sort(unique(out$.uncertainty)), 1:2)
+})
+
+test_that("run_sim: the default falls back to replicates where NWPRI cannot run", {
+  local_pharmr.extra_options()
+  skip_if_nonmem_not_available()
+  withr::local_dir(tempdir())
+
+  ## `n_iterations > 1` used to be perfectly ordinary under the old default, so
+  ## the new default must fall back rather than start aborting those calls.
+  used <- new.env()
+  do.call(local_mocked_bindings, .nwpri_stub_bindings(used))
+  local_mocked_bindings(set_initial_estimates = function(model, inits) model,
+                        .package = "pharmr")
+  out <- run_sim(
+    fit = .fake_fit(), model = make_model_without_cov(), data = .sim_dat(),
+    n_uncertainty = 2, n_iterations = 2, verbose = FALSE
+  )
+  expect_equal(used$engine, "replicates")
+  expect_equal(sort(unique(out$.uncertainty)), 1:2)
+})
+
+test_that("run_sim: naming an engine still errors instead of falling back", {
+  local_pharmr.extra_options()
+  skip_if_nonmem_not_available()
+  withr::local_dir(tempdir())
+
+  args <- list(
+    fit = .fake_fit(),
+    model = make_model_without_cov(), data = .sim_dat(),
+    n_uncertainty = 2, uncertainty_engine = "nwpri", verbose = FALSE
+  )
+  expect_error(do.call(run_sim, c(args, list(n_iterations = 2))),
+               "requires .*n_iterations = 1")
+  expect_error(do.call(run_sim, c(args, list(tool = "nlmixr2"))),
+               "NONMEM feature")
+})
+
+test_that("run_sim: a point-estimate run is unaffected by the engine default", {
+  local_pharmr.extra_options()
+  skip_if_nonmem_not_available()
+  withr::local_dir(tempdir())
+
+  used <- new.env()
+  do.call(local_mocked_bindings, .nwpri_stub_bindings(used))
+  local_mocked_bindings(set_initial_estimates = function(model, inits) model,
+                        .package = "pharmr")
+  ## No `n_uncertainty`, so there is no uncertainty to propagate and NWPRI must
+  ## not be dragged in just because it is the default engine.
+  out <- run_sim(model = make_model_without_cov(), data = .sim_dat(),
+                 verbose = FALSE)
+  expect_equal(used$engine, "replicates")
+  expect_false(".uncertainty" %in% names(out))
+})

--- a/tests/testthat/test-run_sim-nwpri-engine.R
+++ b/tests/testthat/test-run_sim-nwpri-engine.R
@@ -32,6 +32,26 @@ test_that("nwpri_chunk_sizes never asks for more chunks than draws", {
   expect_length(nwpri_chunk_sizes(1, 16), 1L)
 })
 
+test_that("nwpri_worker_count keeps chunks worth their worker process", {
+  ## Starting a worker costs more than the subproblems a small chunk saves, so
+  ## below NWPRI_MIN_DRAWS_PER_CHUNK draws per chunk it stays in one job (#134).
+  expect_equal(nwpri_worker_count(10, 4), 1L)
+  expect_equal(nwpri_worker_count(49, 4), 1L)
+  expect_equal(nwpri_worker_count(50, 4), 1L)
+  expect_equal(nwpri_worker_count(100, 4), 2L)
+  expect_equal(nwpri_worker_count(200, 4), 4L)
+  ## `n_cores` stays a ceiling, not a target
+  expect_equal(nwpri_worker_count(1000, 4), 4L)
+  expect_equal(nwpri_worker_count(1000, 1), 1L)
+  expect_type(nwpri_worker_count(200, 4), "integer")
+})
+
+test_that("nwpri_worker_count validates its input", {
+  expect_error(nwpri_worker_count(0, 2), "positive integer")
+  expect_error(nwpri_worker_count(-1, 2), "positive integer")
+  expect_error(nwpri_worker_count(10, 0), "Number of NWPRI chunks must be a positive integer")
+})
+
 test_that("nwpri_chunk_sizes validates its input", {
   expect_error(nwpri_chunk_sizes(0, 2), "positive integer")
   expect_error(nwpri_chunk_sizes(-1, 2), "positive integer")
@@ -200,8 +220,10 @@ test_that("run_nwpri_regimen chunks the draws over its own run folders", {
   ## PSOCK workers would write the log into their own copy of `log_env`.
   mockery::stub(run_nwpri_regimen, "parallel_lapply",
                 function(X, FUN, n_cores = 1L) lapply(X, FUN))
+  ## Well above NWPRI_MIN_DRAWS_PER_CHUNK * 4, so all four chunks are worth
+  ## their worker and the split really happens (#134).
   out <- run_nwpri_regimen(
-    sim_code = code, dataset = dataset, n_uncertainty = 10, seed = 500,
+    sim_code = code, dataset = dataset, n_uncertainty = 200, seed = 500,
     folder = folder, output_file = "simtab", nmfe = "fake-nmfe",
     n_cores = 4, force = FALSE, verbose = FALSE
   )
@@ -211,13 +233,13 @@ test_that("run_nwpri_regimen chunks the draws over its own run folders", {
   expect_setdiff_empty(paste0("uncertainty_chunk_", 1:4), list.dirs(folder, full.names = FALSE))
 
   ## `.uncertainty` runs 1..n over the chunks, in order.
-  expect_equal(sort(unique(out$.uncertainty)), 1:10)
-  expect_equal(nrow(out), 20)
-  expect_equal(attr(out, "n_uncertainty_kept"), 10)
+  expect_equal(sort(unique(out$.uncertainty)), 1:200)
+  expect_equal(nrow(out), 400)
+  expect_equal(attr(out, "n_uncertainty_kept"), 200)
 
   ## Each chunk got its own seed and its share of the subproblems, and nothing
   ## else about the control stream changed.
-  sizes <- nwpri_chunk_sizes(10, 4)
+  sizes <- nwpri_chunk_sizes(200, 4)
   seeds <- nwpri_chunk_seeds(500, 4)
   for (k in 1:4) {
     mod <- log_env$mods[[as.character(k)]]
@@ -245,7 +267,7 @@ test_that("run_nwpri_regimen gives every chunk its own copy of the dataset", {
                 function(X, FUN, n_cores = 1L) lapply(X, FUN))
   run_nwpri_regimen(
     sim_code = "$PROBLEM t\n$DATA data.csv IGNORE=@\n$THETA (0,1)",
-    dataset = dataset, n_uncertainty = 4, seed = 1,
+    dataset = dataset, n_uncertainty = 100, seed = 1,
     folder = folder, output_file = "simtab", nmfe = "fake-nmfe",
     n_cores = 2, force = FALSE, verbose = FALSE
   )
@@ -288,7 +310,7 @@ test_that("nwpri_draws_kept falls back to the whole table without regimen labels
   expect_equal(nwpri_draws_kept(data.frame(.uncertainty = c(1, 1, 2))), 2L)
 })
 
-test_that("run_nwpri_regimen chunks by n_cores rather than the draw count", {
+test_that("run_nwpri_regimen keeps a run in one job when chunking would not pay", {
   folder <- withr::local_tempdir()
   log_env <- new.env(parent = emptyenv())
   log_env$mods <- list()
@@ -309,6 +331,19 @@ test_that("run_nwpri_regimen chunks by n_cores rather than the draw count", {
   expect_match(grep("^\\$SIM", log_env$mods[["1"]], value = TRUE),
                "SUBPROBLEMS=6")
   expect_equal(sort(unique(out$.uncertainty)), 1:6)
+
+  ## Same with cores to spare: six draws are not worth four worker processes,
+  ## so they stay in a single job (#134).
+  log_env$mods <- list()
+  out4 <- run_nwpri_regimen(
+    sim_code = code, dataset = dataset, n_uncertainty = 6, seed = 1,
+    folder = folder, output_file = "simtab", nmfe = "fake-nmfe",
+    n_cores = 4, force = TRUE, verbose = FALSE
+  )
+  expect_length(log_env$mods, 1)
+  expect_match(grep("^\\$SIM", log_env$mods[["1"]], value = TRUE),
+               "SUBPROBLEMS=6")
+  expect_equal(sort(unique(out4$.uncertainty)), 1:6)
 })
 
 test_that("run_nwpri_regimen refuses to reuse an existing chunk folder", {

--- a/tests/testthat/test-run_sim-parallel.R
+++ b/tests/testthat/test-run_sim-parallel.R
@@ -51,6 +51,58 @@ test_that("parallel_lapply matches lapply and keeps input order", {
   expect_equal(parallel_lapply(1:6, fn, n_cores = 2), expected)
 })
 
+test_that("parallel_lapply falls back to sequential when workers will not start", {
+  skip_on_cran()
+  cl_ok <- tryCatch({
+    cl <- parallel::makePSOCKcluster(2); parallel::stopCluster(cl); TRUE
+  }, error = function(e) FALSE)
+  skip_if_not(cl_ok, "cannot start a PSOCK cluster")
+
+  ## Worker startup fails *before* FUN is ever called, so it is outside
+  ## run_captured()'s reach: unguarded it would take down the whole run rather
+  ## than cost one item (#134).
+  local_mocked_bindings(
+    worker_init_fn = function() {
+      f <- function(path, dev, threads) stop("worker init exploded")
+      environment(f) <- baseenv()
+      f
+    },
+    .package = "pharmr.extra"
+  )
+  fn <- function(i) i^2
+  expect_warning(res <- parallel_lapply(1:4, fn, n_cores = 2),
+                 "running sequentially")
+  ## same results, just not in parallel
+  expect_equal(res, lapply(1:4, fn))
+})
+
+test_that("parallel_lapply retries once before giving up on the workers", {
+  skip_on_cran()
+  cl_ok <- tryCatch({
+    cl <- parallel::makePSOCKcluster(2); parallel::stopCluster(cl); TRUE
+  }, error = function(e) FALSE)
+  skip_if_not(cl_ok, "cannot start a PSOCK cluster")
+
+  ## The failure this guards against is intermittent, so a single retry is
+  ## expected to recover most of them without falling back at all.
+  calls <- 0L
+  local_mocked_bindings(
+    worker_init_fn = function() {
+      calls <<- calls + 1L
+      f <- if(calls == 1L) function(path, dev, threads) stop("transient")
+           else function(path, dev, threads) invisible(NULL)
+      environment(f) <- baseenv()
+      f
+    },
+    .package = "pharmr.extra"
+  )
+  fn <- function(i) i^2
+  ## second attempt succeeds, so no warning and the work really ran on workers
+  expect_no_warning(res <- parallel_lapply(1:4, fn, n_cores = 2))
+  expect_equal(res, lapply(1:4, fn))
+  expect_equal(calls, 2L)
+})
+
 test_that("run_captured captures warnings and converts errors to values", {
   ok <- run_captured(2, function() {
     warning("first problem")
@@ -267,7 +319,8 @@ test_that("run_sim: n_cores > 1 falls back to sequential for NONMEM", {
 
   expect_warning(
     out <- run_sim(fit = fake_fit, model = mod, data = .sim_dat(),
-                   n_uncertainty = 2, n_cores = 2, verbose = FALSE),
+                   n_uncertainty = 2, n_cores = 2,
+                   uncertainty_engine = "replicates", verbose = FALSE),
     "nlmixr2"
   )
   expect_equal(sort(unique(out$.uncertainty)), 1:2)
@@ -308,7 +361,8 @@ test_that("run_sim (nonmem): a failing replicate aborts the run", {
   ## returning a truncated set of draws.
   expect_error(
     run_sim(fit = fake_fit, model = mod, data = .sim_dat(),
-            n_uncertainty = 3, verbose = FALSE),
+            n_uncertainty = 3, uncertainty_engine = "replicates",
+            verbose = FALSE),
     "Uncertainty replicate 2 failed"
   )
   ## and it stops there: the third replicate is never started

--- a/tests/testthat/test-run_sim.R
+++ b/tests/testthat/test-run_sim.R
@@ -682,9 +682,13 @@ test_that("run_sim: warns which parameters are held fixed under n_uncertainty", 
     .package = "pharmr"
   )
 
+  ## The held-fixed warning belongs to the replicate loop, which samples the
+  ## draws in R; NWPRI builds its prior in NONMEM instead, so pin the engine
+  ## rather than depend on which one is the default (#134).
   expect_warning(
     run_sim(fit = fake_fit, model = mod, data = .sim_dat(),
-            n_uncertainty = 2, verbose = FALSE),
+            n_uncertainty = 2, uncertainty_engine = "replicates",
+            verbose = FALSE),
     "POP_V"
   )
 })
@@ -728,7 +732,8 @@ test_that("run_sim (stub): n_uncertainty samples draws and tags .uncertainty col
   )
 
   out <- run_sim(fit = fake_fit, model = mod, data = .sim_dat(),
-                 n_uncertainty = n_draws, verbose = FALSE)
+                 n_uncertainty = n_draws, uncertainty_engine = "replicates",
+                 verbose = FALSE)
 
   expect_equal(sampled, n_draws)
   expect_true(".uncertainty" %in% names(out))
@@ -766,7 +771,8 @@ test_that("run_sim (stub): each replicate perturbs the model with its own draw",
   )
 
   out <- run_sim(fit = fake_fit, model = mod, data = .sim_dat(),
-                 n_uncertainty = n_draws, verbose = FALSE)
+                 n_uncertainty = n_draws, uncertainty_engine = "replicates",
+                 verbose = FALSE)
 
   ## Draws must reach set_initial_estimates once per replicate, in order, each
   ## carrying that replicate's own row -- guards against a regression where the


### PR DESCRIPTION
Closes #134.

Three changes: NWPRI becomes the default uncertainty engine, worker startup stops being able to kill a run, and the NWPRI engine stops chunking when chunking costs more than it saves.

## 1. NWPRI is now the default

`uncertainty_engine` gains `"auto"`, which is the new default. It uses `"nwpri"` where it applies — NONMEM, with `n_iterations = 1` — and `"replicates"` everywhere else. Naming an engine explicitly still errors rather than falling back, so an explicit `"nwpri"` on nlmixr2 or with `n_iterations > 1` fails exactly as before; `"auto"` announces which one it picked under `verbose`.

Measured on a 1-cmt oral model (the NWPRI anchor fixture), 700-row simulation dataset, `n_cores = 4`, NONMEM 7.6.0:

| n_uncertainty | replicates (old default) | nwpri (new default) | speedup |
|---|---|---|---|
| 10 | 5.1 s | 4.9 s | 1.0× |
| 50 | 18.6 s | 4.3 s | 4.3× |
| 200 | 65.3 s | 5.1 s | 12.8× |
| 1000 | 339.2 s | 9.2 s | **37×** |

The replicate loop pays a full NM-TRAN + compile + run per draw, so its cost is linear in `n_uncertainty` (~0.33–0.5 s/draw here). NWPRI pays one compile per chunk and ~0.02 s per additional subproblem, so it is close to flat. Worth noting `n_cores` never helped the replicate loop on NONMEM in the first place — it warns and runs sequentially, confirmed at 17.2 s (`n_cores = 1`) vs 18.6 s (`n_cores = 4`) for 50 draws — so this is where parallelism actually arrives for that backend.

**The trade**, documented on `run_sim()` and in `NEWS.md`. NWPRI draws OMEGA/SIGMA from inverse-Wishart distributions and treats the THETA, OMEGA and SIGMA priors as independent blocks, discarding the THETA-OMEGA and THETA-SIGMA covariances `$COVARIANCE` reports; aggregates still agree with the replicate draws to within a few percent (`inst/reports/nwpri-validation.html`). And NWPRI cannot hold the simulated individuals fixed across draws the way `"replicates"` now does (#131), so an interval over `.uncertainty` also carries the Monte-Carlo noise of re-simulating the subjects. That noise shrinks as the simulation dataset and `n_uncertainty` grow — the regime the speed difference makes practical — which is the basis for the call. `uncertainty_engine = "replicates"` restores the old behaviour.

Calls passing `n_iterations > 1` were perfectly ordinary under the old default, so `"auto"` falls back for them instead of starting to abort. There is a test for exactly that.

## 2. Worker startup can no longer take down a run

Bringing up the cluster happens before any work function is called, so it sat outside `run_captured()`'s error handling. An intermittent failure in a worker's `loadNamespace()` — observed inside rxode2's `.onLoad`, see #134 for the diagnosis — aborted the whole `run_sim()` call rather than costing one chunk.

`parallel_lapply()` now retries once and then falls back to running everything sequentially, with a warning. Same results, only slower. This covers the nlmixr2 parallel replicate path too, which shares the code.

The root cause of the rxode2 `.onLoad` failure is still unidentified — it reproduced twice out of ~10 runs and would not reproduce on demand — so this makes the symptom survivable rather than fixing the cause. #134 keeps the detail.

## 3. No chunking that costs more than it saves

Each extra NWPRI chunk buys a concurrent NONMEM process but costs a worker process to start and load the package: ~1.4 s for four workers, measured, against ~0.02 s per subproblem. Below roughly 50 draws per chunk that is a net loss — 50 draws took 2.6 s in one job versus 4.3 s split over four. `nwpri_worker_count()` now treats `n_cores` as a ceiling rather than a target, so small runs stay in a single job.

## Testing

New `tests/testthat/test-run_sim-engine-default.R`: engine resolution for each case, the messages it emits, `run_sim()` actually taking the NWPRI branch by default, falling back for `n_iterations > 1`, still erroring on an explicit request it cannot honour, and a point-estimate run not dragging NWPRI in.

Added to the existing files: `nwpri_worker_count()` (floor, ceiling, validation), `parallel_lapply()` falling back to sequential when workers will not start, and retrying once before it does. Existing NWPRI chunking tests were raised above the new floor so they still exercise chunking, with a case added for a small run staying in one job.

Six tests that exercise the replicate loop now pin `uncertainty_engine = "replicates"` instead of relying on it being the default — the held-fixed warning, the two stub replicate tests, the NONMEM common-random-numbers test, and two parallel-path tests.

Full suite: 0 failed, 0 errors, 2364 passed, 119 skipped. Running with the NONMEM/Pharmpy skip disabled to reach the gated tests gives 12 failures, all of which are present identically on `main` (they need a real NONMEM install); diffing against a `main` baseline shows **0 new failures**.

End-to-end against real NONMEM 7.6.0 with defaults only: `Using the "nwpri" uncertainty engine` → 200 draws in 4 NONMEM jobs, 6.9 s, 140000 rows; and with `n_iterations = 2`, `Using the "replicates" uncertainty engine (n_iterations = 2; ...)` as intended.

### One pre-existing bug found, not fixed here

`run_sim()` on the sequential NONMEM replicate path with `verbose = TRUE` dies in cli's progress bar under `Rscript`:

```
Error in app$status_bar[[1]] : subscript out of bounds
Calls: run_sim ... do.call -> <Anonymous> -> clii_status_update -> paste0
```

Verified identical on `main` with main's own default, so it predates this PR and is out of scope. It is worth its own issue — note this PR makes that path less travelled (it is now only reached on fallback) but does not remove it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
